### PR TITLE
Reversibility audit: faithful -inverse output, integer literals, expanded tests

### DIFF
--- a/example/algo_josephus.rplpp
+++ b/example/algo_josephus.rplpp
@@ -1,0 +1,33 @@
+// Reversible Josephus problem
+// n people in a circle, every k-th person is eliminated
+// Records elimination order for reversibility
+// J(n, k) using the recurrence: J(1)=0, J(n) = (J(n-1)+k) mod n
+// n=7, k=3 -> survivor position = 3 (0-indexed)
+
+class Josephus
+    method solve(int n, int k, int result, int[] hist)
+        result ^= 0
+        for i in (2..n) do
+            hist[i-2] += result
+            local int tmp = result + k
+            local int r = tmp % i
+            result -= result
+            result += r
+            delocal int r = result
+            delocal int tmp = result + i * ((hist[i-2] + k) / i)
+        end
+
+class Program
+    int result
+    int[] hist
+    method main()
+        new int[6] hist
+        local Josephus j = nil
+        new Josephus j
+        local int n = 7
+        local int k = 3
+        call j::solve(n, k, result, hist)
+        delocal int k = 3
+        delocal int n = 7
+        delete Josephus j
+        delocal Josephus j = nil

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -38,18 +38,36 @@ let incr_lineno (lexbuf:Lexing.lexbuf) : unit =
                         pos_lnum = pos.pos_lnum + 1;
                         pos_bol = pos.pos_cnum;
                       }
+
+(* 文字リテラルの整数コード。引数は前後のクォートを含む字句 'A' / '\n' 等。
+   1バイト ASCII 文字のみ対応（マルチバイト UTF-8 は字句規則が弾く）。 *)
+let decode_char (s:string) : int =
+  if String.length s = 3 then Char.code s.[1]   (* 'A' *)
+  else match s.[2] with                         (* '\n' '\t' '\\' '\'' '\"' *)
+    | 'n' -> Char.code '\n'
+    | 't' -> Char.code '\t'
+    | c   -> Char.code c
 }
 
 let digit = ['0'-'9']
+let hexdigit = ['0'-'9' 'a'-'f' 'A'-'F']
+let bindigit = ['0'-'1']
 let alpha = ['A'-'Z' 'a'-'z' '_']
 let alnum = digit | alpha | '\''
 let u = ['\000'-'\255']           (* universal: any character *)
 
 rule token = parse
-  (* 定数 *)
+  (* 定数。16進 0x.. / 2進 0b.. / 文字 'A' はいずれも CONST に落とす
+     （int_of_string が 0x/0b/0o を解釈。文字は ASCII コード）。 *)
+  | ("0x"|"0X") hexdigit+
+    { CONST (int_of_string (Lexing.lexeme lexbuf)) }
+  | ("0b"|"0B") bindigit+
+    { CONST (int_of_string (Lexing.lexeme lexbuf)) }
   | digit+
     { let str = Lexing.lexeme lexbuf in
       CONST (int_of_string str) }
+  | '\'' ((u # ['\'' '\\' '\n']) | ('\\' ('\'' | '\\' | '\"' | 'n' | 't'))) '\''
+    { CONST (decode_char (Lexing.lexeme lexbuf)) }
   | '\"' ((u # ['\"' '\\' '\n']) | ('\\' ('\"' | '\\' | '\'' | 'n' | 't')) | ('\\' digit digit digit))* '\"' {let s = lexeme lexbuf in STRING (unescapeInitTail s)}
 
   (* コメント *)

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -4,10 +4,20 @@ open Syntax
 open Lexing
 
 let unescapeInitTail (s:string) : string =
+  let is_digit c = c >= '0' && c <= '9' in
   let rec unesc s = match s with
       '\\'::c::cs when List.mem c ['\"'; '\\'; '\''] -> c :: unesc cs
     | '\\'::'n'::cs  -> '\n' :: unesc cs
     | '\\'::'t'::cs  -> '\t' :: unesc cs
+    (* \DDD : 10進3桁エスケープ。pretty.ml の escape_string_literal が
+       制御文字（ESC, NUL 等）に対して出力する。0..255 のみ採用し、
+       範囲外（\256 以上）は次の規則でバックスラッシュをそのまま通す。 *)
+    | '\\'::d1::d2::d3::cs
+         when is_digit d1 && is_digit d2 && is_digit d3
+              && (Char.code d1 - 48) * 100 + (Char.code d2 - 48) * 10
+                 + (Char.code d3 - 48) < 256 ->
+       Char.chr ((Char.code d1 - 48) * 100 + (Char.code d2 - 48) * 10
+                 + (Char.code d3 - 48)) :: unesc cs
     | '\"'::[]    -> []
     | c::cs      -> c :: unesc cs
     | _         -> []
@@ -40,7 +50,7 @@ rule token = parse
   | digit+
     { let str = Lexing.lexeme lexbuf in
       CONST (int_of_string str) }
-  | '\"' ((u # ['\"' '\\' '\n']) | ('\\' ('\"' | '\\' | '\'' | 'n' | 't')))* '\"' {let s = lexeme lexbuf in STRING (unescapeInitTail s)}
+  | '\"' ((u # ['\"' '\\' '\n']) | ('\\' ('\"' | '\\' | '\'' | 'n' | 't')) | ('\\' digit digit digit))* '\"' {let s = lexeme lexbuf in STRING (unescapeInitTail s)}
 
   (* コメント *)
   | "//" [^'\n']* { token lexbuf }

--- a/src/pretty.ml
+++ b/src/pretty.ml
@@ -5,6 +5,22 @@ open Syntax
 let rec indent n = if n = 0 then ""
                    else indent (n - 1) ^ "    "
 
+(**文字列リテラルを lexer が再読込できる形にエスケープする関数。
+   lexer.mll の文字列規則は "\\\"" "\\\\" "\\n" "\\t" のみ受理し、
+   それ以外のバイト（UTF-8 日本語等を含む ≥128）は生のまま受理する。
+   OCaml の String.escaped は ≥128 を \DDD（10進エスケープ）にしてしまい
+   lexer が再読込できないため、ここでは lexer 互換のエスケープのみ行う。*)
+let escape_string_literal (s : string) : string =
+  let buf = Buffer.create (String.length s) in
+  String.iter (fun c ->
+    match c with
+    | '"'  -> Buffer.add_string buf "\\\""
+    | '\\' -> Buffer.add_string buf "\\\\"
+    | '\n' -> Buffer.add_string buf "\\n"
+    | '\t' -> Buffer.add_string buf "\\t"
+    | _    -> Buffer.add_char buf c) s;
+  Buffer.contents buf
+
 (**型をプリントする関数*)
 let pretty_dataType = function
   | IntegerType -> "int"
@@ -111,7 +127,7 @@ pretty_stm stm n =
     | ArrayDestruction((typeId, exp), obj) -> "delete " ^ typeId ^ "[" ^ pretty_exp exp ^ "] " ^ pretty_obj obj
     | Skip -> "skip"
     | Show(exp) -> "show" ^ "(" ^ pretty_exp exp ^ ")"
-    | Print(str) -> "print" ^ "(\""  ^ String.escaped str ^ "\")"
+    | Print(str) -> "print" ^ "(\""  ^ escape_string_literal str ^ "\")"
     in
     s
 

--- a/src/pretty.ml
+++ b/src/pretty.ml
@@ -6,10 +6,15 @@ let rec indent n = if n = 0 then ""
                    else indent (n - 1) ^ "    "
 
 (**文字列リテラルを lexer が再読込できる形にエスケープする関数。
-   lexer.mll の文字列規則は "\\\"" "\\\\" "\\n" "\\t" のみ受理し、
-   それ以外のバイト（UTF-8 日本語等を含む ≥128）は生のまま受理する。
-   OCaml の String.escaped は ≥128 を \DDD（10進エスケープ）にしてしまい
-   lexer が再読込できないため、ここでは lexer 互換のエスケープのみ行う。*)
+   lexer.mll の文字列規則は "\\\"" "\\\\" "\\'" "\\n" "\\t" と \DDD（10進3桁）を
+   受理し、それ以外のバイト（UTF-8 日本語等を含む ≥128）は生のまま受理する。
+   方針:
+   - " \ は \" \\ に、改行・タブは \n \t にする。
+   - 制御文字（< 0x20）と DEL(0x7f) は \DDD にする。生のまま出すと -inverse の
+     端末出力に ANSI エスケープ（ESC=0x1b）等が混入し、再生成ソースに NUL 等の
+     制御バイトが埋まるため。改行は raw だと lexer が文字列の途中で切るので必須。
+   - 0x20..0x7e（" \ を除く）と ≥0x80（UTF-8）は生のまま通す（日本語可読性のため）。
+   OCaml の String.escaped は ≥128 も \DDD にしてしまい日本語が壊れるので使わない。*)
 let escape_string_literal (s : string) : string =
   let buf = Buffer.create (String.length s) in
   String.iter (fun c ->
@@ -18,7 +23,9 @@ let escape_string_literal (s : string) : string =
     | '\\' -> Buffer.add_string buf "\\\\"
     | '\n' -> Buffer.add_string buf "\\n"
     | '\t' -> Buffer.add_string buf "\\t"
-    | _    -> Buffer.add_char buf c) s;
+    | c when Char.code c < 0x20 || Char.code c = 0x7f ->
+       Buffer.add_string buf (Printf.sprintf "\\%03d" (Char.code c))
+    | c    -> Buffer.add_char buf c) s;
   Buffer.contents buf
 
 (**型をプリントする関数*)
@@ -57,14 +64,23 @@ let pretty_modOp = function
   | ModSub -> "-="
   | ModXor -> "^="
 
-(**式をプリントする関数*)
+(**式をプリントする関数。
+   二項演算の被演算子が二項演算のときは括弧で囲む。こうしないと優先順位の
+   違いで再パース時にグループ化が失われる（例: i * ((a + k) / i) が
+   i * a + k / i になってしまう）。( e ) はパーサで捨てられ AST に残らない
+   ため、常に括弧を付けても parse(pretty p) = p は保たれる。*)
 let rec pretty_exp = function
   | Const n -> string_of_int n
   | Var id -> id
   | ArrayElement(id, exp) -> id ^ "[" ^ pretty_exp exp ^ "]"
   | Nil -> "nil"
-  | Binary(binOp, exp1, exp2) -> pretty_exp exp1 ^ " " ^ pretty_binOp binOp ^ " " ^ pretty_exp exp2
+  | Binary(binOp, exp1, exp2) ->
+     paren_binary exp1 ^ " " ^ pretty_binOp binOp ^ " " ^ paren_binary exp2
   | Dot(exp1, exp2) -> pretty_exp exp1 ^ "." ^ pretty_exp exp2
+(**被演算子が二項演算なら括弧で囲む（添字 e[..] や Dot は不要）*)
+and paren_binary = function
+  | Binary _ as e -> "(" ^ pretty_exp e ^ ")"
+  | e -> pretty_exp e
 
 (**変数、配列、ドット演算子をプリントする関数*)
 let rec pretty_obj = function

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 #
-all: test_eval test_invert test_print
+all: test_eval test_invert test_print test_pretty test_env
 
 test_eval: eval_test.byte
 	./eval_test.byte
@@ -23,6 +23,20 @@ test_print: print_test.byte
 print_test.byte: 		print_test.ml
 	(cd ../src; make)
 	ocamlfind ocamlc -o $@ -package ounit2 -linkpkg -g -I ../src value.cmo print.cmo print_test.ml
+
+test_pretty: pretty_test.byte
+	./pretty_test.byte
+
+pretty_test.byte: 		pretty_test.ml
+	(cd ../src; make)
+	ocamlfind ocamlc -o $@ -package ounit2 -linkpkg -g -I ../src util.cmo syntax.cmo value.cmo pretty.cmo pretty_test.ml
+
+test_env: env_store_test.byte
+	./env_store_test.byte
+
+env_store_test.byte: 		env_store_test.ml
+	(cd ../src; make)
+	ocamlfind ocamlc -o $@ -package ounit2 -linkpkg -g -I ../src util.cmo pretty.cmo invert.cmo print.cmo value.cmo syntax.cmo eval.cmo env_store_test.ml
 
 clean:
 	$(RM) *.byte

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,42 +1,51 @@
 #
 # Makefile
 #
-all: test_eval test_invert test_print test_pretty test_env
+all: test_eval test_invert test_print test_pretty test_env test_eval_prog
+
+# Build the interpreter objects in ../src exactly once per make run.
+# Used as an order-only prerequisite (after the | in each *.byte rule) so the
+# src build is shared by all suites instead of being re-invoked once per suite,
+# while a byte still only relinks when its own _test.ml changes.
+.PHONY: build-src
+build-src:
+	(cd ../src; make)
 
 test_eval: eval_test.byte
 	./eval_test.byte
 
-eval_test.byte: 		eval_test.ml
-	(cd ../src; make)
+eval_test.byte: 		eval_test.ml | build-src
 	ocamlfind ocamlc -o $@ -package ounit2 -linkpkg -g -I ../src util.cmo pretty.cmo invert.cmo print.cmo eval.cmo value.cmo syntax.cmo eval_test.ml
 
 test_invert: invert_test.byte
 	./invert_test.byte
 
-invert_test.byte: 		invert_test.ml
-	(cd ../src; make)
+invert_test.byte: 		invert_test.ml | build-src
 	ocamlfind ocamlc -o $@ -package ounit2 -linkpkg -g -I ../src invert.cmo syntax.cmo invert_test.ml
 
 test_print: print_test.byte
 	./print_test.byte
 
-print_test.byte: 		print_test.ml
-	(cd ../src; make)
+print_test.byte: 		print_test.ml | build-src
 	ocamlfind ocamlc -o $@ -package ounit2 -linkpkg -g -I ../src value.cmo print.cmo print_test.ml
 
 test_pretty: pretty_test.byte
 	./pretty_test.byte
 
-pretty_test.byte: 		pretty_test.ml
-	(cd ../src; make)
+pretty_test.byte: 		pretty_test.ml | build-src
 	ocamlfind ocamlc -o $@ -package ounit2 -linkpkg -g -I ../src util.cmo syntax.cmo value.cmo pretty.cmo pretty_test.ml
 
 test_env: env_store_test.byte
 	./env_store_test.byte
 
-env_store_test.byte: 		env_store_test.ml
-	(cd ../src; make)
+env_store_test.byte: 		env_store_test.ml | build-src
 	ocamlfind ocamlc -o $@ -package ounit2 -linkpkg -g -I ../src util.cmo pretty.cmo invert.cmo print.cmo value.cmo syntax.cmo eval.cmo env_store_test.ml
+
+test_eval_prog: eval_prog_test.byte
+	./eval_prog_test.byte
+
+eval_prog_test.byte: 		eval_prog_test.ml | build-src
+	ocamlfind ocamlc -o $@ -package ounit2 -linkpkg -g -I ../src util.cmo syntax.cmo value.cmo pretty.cmo invert.cmo print.cmo eval.cmo parser.cmo lexer.cmo eval_prog_test.ml
 
 clean:
 	$(RM) *.byte

--- a/test/eval_prog_test.ml
+++ b/test/eval_prog_test.ml
@@ -133,11 +133,31 @@ class Program
     delocal int t = (result + n * ((k + n) / n)) + t
 |}
 
+(* ---- integer-literal forms: hex / binary / char ---------------------- *)
+
+(* Hex (0x..), binary (0b..) and char ('A') literals all lex to a plain
+   Const, so they need no parser/eval/invert changes and pretty-print back as
+   decimal (the AST round-trips, the surface form is not preserved). *)
+let hex_src     = "class Program\n int result\n method main()\n  result ^= 0xFF\n"
+let hex_up_src  = "class Program\n int result\n method main()\n  result ^= 0X10\n"
+let bin_src     = "class Program\n int result\n method main()\n  result ^= 0b1010\n"
+let char_src    = "class Program\n int result\n method main()\n  result ^= 'A'\n"
+let charesc_src = "class Program\n int result\n method main()\n  result ^= '\\n'\n"
+
+let literal_tests = "integer literal forms" >::: [
+    "hex 0xFF = 255"   >:: (fun _ -> assert_equal [("result", IntVal 255)] (run hex_src));
+    "hex 0X10 = 16"    >:: (fun _ -> assert_equal [("result", IntVal 16)]  (run hex_up_src));
+    "binary 0b1010=10" >:: (fun _ -> assert_equal [("result", IntVal 10)]  (run bin_src));
+    "char 'A' = 65"    >:: (fun _ -> assert_equal [("result", IntVal 65)]  (run char_src));
+    "char '\\n' = 10"  >:: (fun _ -> assert_equal [("result", IntVal 10)]  (run charesc_src));
+  ]
+
 (* ---- reversibility properties over parsed programs ------------------ *)
 
 let named_progs =
   [ "fib", fib_src; "forsum", forsum_src; "cond", cond_src; "local", local_src;
-    "roundtrip", roundtrip_src ]
+    "roundtrip", roundtrip_src;
+    "hex", hex_src; "binary", bin_src; "char", char_src ]
 
 let double_invert_tests =
   "invert_prog is an involution" >::: List.map
@@ -157,5 +177,6 @@ let reparse_tests =
 
 let _ =
   run_test_tt_main eval_tests;
+  run_test_tt_main literal_tests;
   run_test_tt_main double_invert_tests;
   run_test_tt_main reparse_tests

--- a/test/eval_prog_test.ml
+++ b/test/eval_prog_test.ml
@@ -1,0 +1,161 @@
+open OUnit2
+open Syntax
+open Value
+open Eval
+
+(* End-to-end tests for the whole pipeline: lexer -> parser -> eval_prog.
+   The other suites exercise eval_state/eval_exp on hand-built ASTs; this
+   one starts from ROOPL++ source text, so it is the only coverage of
+   lexer.mll / parser.mly and of eval_prog (main-method lookup, field
+   environment/store construction, final result projection).
+
+   It also checks the two reversibility properties that must hold for every
+   parsed program:
+     - double inversion is the identity:      invert (invert p) = p
+     - pretty output re-parses to the same AST: parse (pretty p) = p
+   The second guards the -inverse feature, whose output is fed back to the
+   parser (see the pretty.ml string-escaping regression, 2026-06-03). *)
+
+let parse src = Parser.main Lexer.token (Lexing.from_string src)
+let run src = eval_prog (parse src)
+let src_of (Prog cl) = Pretty.pretty_cl cl
+
+(* ---- example programs with known results ---------------------------- *)
+
+(* Fibonacci, mirroring example/fib.rplpp: fib(4) leaves xs[1] = 8 in
+   result; n is restored to 4 by the symmetric uncall. *)
+let fib_src = {|
+class Fib
+  int[] xs
+  method init()
+    new int[2] xs
+  method fib(int n)
+    if n = 0 then
+      xs[0] ^= 1
+      xs[1] ^= 1
+    else
+      n -= 1
+      call fib(n)
+      xs[0] += xs[1]
+      xs[0] <=> xs[1]
+    fi xs[0] = xs[1]
+  method get(int out)
+    out ^= xs[1]
+class Program
+  int result
+  int n
+  method main()
+    n ^= 4
+    local Fib f = nil
+    new Fib f
+    call f::init()
+    call f::fib(n)
+    call f::get(result)
+    uncall f::fib(n)
+    uncall f::init()
+    delete Fib f
+    delocal Fib f = nil
+|}
+
+(* sum_{i=1}^{10} i = 55, via a for loop inside a method called by reference. *)
+let forsum_src = {|
+class C
+  method add(int n)
+    for i in (1..10) do
+      n += i
+    end
+class Program
+  int result
+  method main()
+    local C c = nil
+    new C c
+    call c::add(result)
+    delete C c
+    delocal C c = nil
+|}
+
+(* if/fi with matching entry and exit assertions. *)
+let cond_src = {|
+class Program
+  int x
+  method main()
+    x ^= 5
+    if x = 5 then
+      x += 10
+    else
+      x -= 10
+    fi x = 15
+|}
+
+(* local/delocal block with arithmetic; result ends at 8, n is delocal'd away. *)
+let local_src = {|
+class Program
+  int result
+  method main()
+    local int n = 5
+    n += 3
+    result ^= n
+    delocal int n = 8
+|}
+
+let eval_tests = "eval_prog end-to-end" >::: [
+    "fib(4) -> result=8, n restored to 4" >:: (fun _ ->
+      assert_equal [("result", IntVal 8); ("n", IntVal 4)] (run fib_src));
+
+    "for-loop sum 1..10 = 55" >:: (fun _ ->
+      assert_equal [("result", IntVal 55)] (run forsum_src));
+
+    "if/fi taken branch" >:: (fun _ ->
+      assert_equal [("x", IntVal 15)] (run cond_src));
+
+    "local block arithmetic" >:: (fun _ ->
+      assert_equal [("result", IntVal 8)] (run local_src));
+  ]
+
+(* Exercises the two pretty-printer hazards that the reparse property must
+   catch, neither of which the four programs above contain:
+     - arithmetic whose grouping is lost without parentheses
+       (result + n * ((k + n) / n) would re-parse differently if the inner
+        parens were dropped — the josephus -inverse bug), and
+     - a Print literal with non-ASCII (UTF-8) text and a control byte (ESC),
+       which must survive escape_string_literal -> lexer round-tripping. *)
+let roundtrip_src = {|
+class Program
+  int result
+  int n
+  int k
+  method main()
+    n ^= 6
+    k ^= 1
+    print("\027[1m走査\027[0m\n")
+    local int t = result + n * ((k + n) / n)
+    t += t
+    delocal int t = (result + n * ((k + n) / n)) + t
+|}
+
+(* ---- reversibility properties over parsed programs ------------------ *)
+
+let named_progs =
+  [ "fib", fib_src; "forsum", forsum_src; "cond", cond_src; "local", local_src;
+    "roundtrip", roundtrip_src ]
+
+let double_invert_tests =
+  "invert_prog is an involution" >::: List.map
+    (fun (name, src) ->
+      name >:: (fun _ ->
+        let p = parse src in
+        assert_equal p (Invert.invert_prog (Invert.invert_prog p))))
+    named_progs
+
+let reparse_tests =
+  "pretty output re-parses to the same AST" >::: List.map
+    (fun (name, src) ->
+      name >:: (fun _ ->
+        let p = parse src in
+        assert_equal p (parse (src_of p))))
+    named_progs
+
+let _ =
+  run_test_tt_main eval_tests;
+  run_test_tt_main double_invert_tests;
+  run_test_tt_main reparse_tests

--- a/test/eval_test.ml
+++ b/test/eval_test.ml
@@ -844,5 +844,56 @@ let tests = "test suite for eval.ml" >::: [
         ArrayDestruction (("Super", Const 2), VarArray("ts", None))])]
 )]
        ) )) 
-]    
-let _ = run_test_tt_main tests
+]
+
+(* Runtime reversibility: running a statement list forward and then its
+   inverse must restore the store exactly. The suite above checks forward
+   evaluation of each construct; this one ties eval.ml together with
+   invert.ml and asserts the law that makes the language reversible,
+   namely  eval_state (s @ invert s) = id  on the store.
+   (eval_state keeps the store sorted by location, so each st0 below is
+   written in sorted order to compare equal.) *)
+let reversible =
+  "reversibility: eval (s @ invert s) restores the store" >:::
+  List.map
+    (fun (title, env, st0, stml) ->
+      title >:: (fun _ ->
+        assert_equal st0 (eval_state (stml @ Invert.invert stml) env [] st0)))
+    [ "x += 5", ["x", 1], [(1, IntVal 10)],
+      [Assign(VarArray("x", None), ModAdd, Const 5)];
+
+      "swap x y", ["x", 1; "y", 2], [(1, IntVal 10); (2, IntVal 5)],
+      [Swap(VarArray("x", None), VarArray("y", None))];
+
+      "if/fi", ["x", 1], [(1, IntVal 0)],
+      [Conditional(Binary(Eq, Var "x", Const 0),
+                   [Assign(VarArray("x", None), ModAdd, Const 1)],
+                   [Assign(VarArray("x", None), ModSub, Const 1)],
+                   Binary(Eq, Var "x", Const 1))];
+
+      "from/loop/until", ["x", 1], [(1, IntVal 0)],
+      [Loop(Binary(Eq, Var "x", Const 0),
+            [Skip],
+            [Assign(VarArray("x", None), ModAdd, Const 1)],
+            Binary(Eq, Var "x", Const 10))];
+
+      "for i in (1..10)", ["x", 1], [(1, IntVal 0)],
+      [For("i", Const 1, Const 10, [Assign(VarArray("x", None), ModAdd, Var "i")])];
+
+      "array element x[0] += 1", ["x", 1],
+      [(1, LocsVec [2; 3]); (2, IntVal 0); (3, IntVal 0)],
+      [Assign(VarArray("x", Some(Const 0)), ModAdd, Const 1)];
+
+      "local block", ["x", 1], [(1, IntVal 0)],
+      [LocalBlock(IntegerType, "n", Const 5,
+                  [Assign(VarArray("x", None), ModAdd, Var "n")], Const 5)];
+
+      "sequence", ["x", 1; "y", 2], [(1, IntVal 3); (2, IntVal 7)],
+      [Assign(VarArray("x", None), ModAdd, Var "y");
+       Swap(VarArray("x", None), VarArray("y", None));
+       Assign(VarArray("y", None), ModXor, Const 4)];
+    ]
+
+let _ =
+  run_test_tt_main tests;
+  run_test_tt_main reversible

--- a/test/invert_test.ml
+++ b/test/invert_test.ml
@@ -99,6 +99,63 @@ let tests1 = "test suite for invert.ml" >::: [
                              Assign (VarArray("x", None), ModAdd, Const 3)] ) );      
 ]
           
+(* Involution: inverting twice is the identity. This is the defining law of
+   the source-to-source inverter and the basis of the -inverse feature
+   (running a program then its inverse must restore the start). tests2 above
+   pins down each constructor's single inverse; this suite checks every
+   constructor survives a round trip, including the non-trivial Switch
+   rewrite (case fall-through / break bookkeeping in invert.ml). *)
+let tests3 = "involution: invert (invert s) = s" >:::
+  List.map
+    (fun (title, stml) ->
+      title >:: (fun _ -> assert_equal stml (invert (invert stml))))
+    [ "skip", [Skip];
+      "assign +=", [Assign(VarArray("x", None), ModAdd, Const 1)];
+      "assign ^=", [Assign(VarArray("x", None), ModXor, Var "y")];
+      "swap", [Swap(VarArray("x", None), VarArray("y", None))];
+      "conditional",
+      [Conditional(Binary(Eq, Var "x", Const 0),
+                   [Assign(VarArray("x", None), ModAdd, Const 1)],
+                   [Skip],
+                   Binary(Eq, Var "x", Const 1))];
+      "loop",
+      [Loop(Binary(Eq, Var "x", Const 0),
+            [Skip],
+            [Assign(VarArray("x", None), ModAdd, Const 1)],
+            Binary(Eq, Var "x", Const 10))];
+      "for",
+      [For("i", Const 1, Const 10, [Assign(VarArray("x", None), ModAdd, Var "i")])];
+      "object block",
+      [ObjectBlock("C", "t", [Assign(VarArray("x", None), ModSub, Const 1)])];
+      "local block",
+      [LocalBlock(IntegerType, "i", Const 0,
+                  [Assign(VarArray("i", None), ModAdd, Const 1)], Const 1)];
+      "local call", [LocalCall("q", [Id "a"])];
+      "local uncall", [LocalUncall("q", [Id "a"])];
+      "object call", [ObjectCall(VarArray("t", None), "q", [Id "a"])];
+      "object uncall", [ObjectUncall(VarArray("t", None), "q", [Id "a"])];
+      "construct", [ObjectConstruction("C", VarArray("t", None))];
+      "destruct", [ObjectDestruction("C", VarArray("t", None))];
+      "copy", [CopyReference(ObjectType "C", VarArray("a", None), VarArray("b", None))];
+      "uncopy", [UncopyReference(ObjectType "C", VarArray("a", None), VarArray("b", None))];
+      "array construct", [ArrayConstruction(("int", Const 2), VarArray("xs", None))];
+      "array destruct", [ArrayDestruction(("int", Const 2), VarArray("xs", None))];
+      "show", [Show(Var "x")];
+      "print", [Print "hi"];
+      "switch with fall-through",
+      [Switch(VarArray("x", None),
+              [((Case, [Const 0]), [Print "0"], (Esac, [Const 0], Break));
+               ((Case, [Const 1]), [Print "a"], (NoEsac, [], NoBreak));
+               ((Case, [Const 2]), [Print "b"], (NoEsac, [], NoBreak));
+               ((Case, [Const 3]), [Print "c"], (Esac, [Const 3; Const 2; Const 1], Break))],
+              [Skip], VarArray("x", None))];
+      "sequence",
+      [Assign(VarArray("x", None), ModAdd, Const 1);
+       Swap(VarArray("x", None), VarArray("y", None));
+       Assign(VarArray("y", None), ModSub, Const 2)];
+    ]
+
 let _ =
   run_test_tt_main tests1;
   run_test_tt_main tests2;
+  run_test_tt_main tests3;

--- a/test/pretty_test.ml
+++ b/test/pretty_test.ml
@@ -1,4 +1,5 @@
 open OUnit2
+open Syntax
 open Pretty
 
 (* Regression tests for the string-literal escaping used by -inverse output.
@@ -30,6 +31,49 @@ let tests = "test suite for pretty.ml string escaping" >::: [
 
       "plain ASCII is unchanged" >:: (fun _ ->
         assert_equal ~printer:(fun x -> x) "hello" (escape_string_literal "hello"));
+
+      (* Control / non-printable bytes must NOT be emitted raw (a raw ESC would
+         inject an ANSI sequence into -inverse output, a raw NUL would corrupt
+         regenerated source). They are escaped as \DDD, which lexer.mll now
+         re-lexes. UTF-8 bytes (>= 0x80) still pass through verbatim (above). *)
+      "ESC (0x1b) becomes \\027" >:: (fun _ ->
+        assert_equal ~printer:(fun x -> x) "\\027" (escape_string_literal "\x1b"));
+
+      "NUL (0x00) becomes \\000" >:: (fun _ ->
+        assert_equal ~printer:(fun x -> x) "\\000" (escape_string_literal "\x00"));
+
+      "DEL (0x7f) becomes \\127" >:: (fun _ ->
+        assert_equal ~printer:(fun x -> x) "\\127" (escape_string_literal "\x7f"));
     ]
 
-let _ = run_test_tt_main tests
+(* pretty_exp must parenthesize a binary operand that is itself a binary
+   expression, otherwise non-default-precedence grouping is lost when the
+   -inverse output is re-parsed. Regression for the josephus example, whose
+   `i * ((a + k) / i)` previously printed as `i * a + k / i`. *)
+let exp_tests = "test suite for pretty.ml expression parenthesizing" >::: [
+      "no spurious parens for a flat expression" >:: (fun _ ->
+        assert_equal ~printer:(fun x -> x) "1 + 2"
+          (pretty_exp (Binary(Add, Const 1, Const 2))));
+
+      "grouping that changes the value is preserved" >:: (fun _ ->
+        (* i * ((hist[i - 2] + k) / i) *)
+        let e = Binary(Mul, Var "i",
+                       Binary(Div,
+                              Binary(Add, ArrayElement("hist", Binary(Sub, Var "i", Const 2)), Var "k"),
+                              Var "i")) in
+        assert_equal ~printer:(fun x -> x)
+          "i * ((hist[i - 2] + k) / i)" (pretty_exp e));
+
+      "left-nested same-precedence keeps grouping" >:: (fun _ ->
+        (* (a - b) - c, which differs from a - (b - c) *)
+        let e = Binary(Sub, Binary(Sub, Var "a", Var "b"), Var "c") in
+        assert_equal ~printer:(fun x -> x) "(a - b) - c" (pretty_exp e));
+
+      "array index is delimited by brackets, not parens" >:: (fun _ ->
+        assert_equal ~printer:(fun x -> x) "xs[i + 1]"
+          (pretty_exp (ArrayElement("xs", Binary(Add, Var "i", Const 1)))));
+    ]
+
+let _ =
+  run_test_tt_main tests;
+  run_test_tt_main exp_tests

--- a/test/pretty_test.ml
+++ b/test/pretty_test.ml
@@ -1,0 +1,35 @@
+open OUnit2
+open Pretty
+
+(* Regression tests for the string-literal escaping used by -inverse output.
+   Bug (reversibility audit, 2026-06-03): pretty.ml printed Print(str) with
+   OCaml String.escaped, which renders bytes >= 128 (UTF-8 / Japanese text)
+   as decimal escapes that lexer.mll cannot re-lex, so the inverse output
+   could not be parsed back. escape_string_literal must emit only the escapes
+   the lexer accepts (quote, backslash, newline, tab) and pass every other
+   byte through verbatim. *)
+
+let tests = "test suite for pretty.ml string escaping" >::: [
+      (* The key regression: non-ASCII (UTF-8) bytes must pass through raw,
+         not become decimal escapes. Six UTF-8 bytes here. *)
+      "non-ASCII bytes are verbatim" >:: (fun _ ->
+        let s = "\xe8\xb5\xb0\xe6\x9f\xbb" in
+        assert_equal ~printer:(fun x -> x) s (escape_string_literal s));
+
+      "double quote is escaped" >:: (fun _ ->
+        assert_equal ~printer:(fun x -> x) "a\\\"b" (escape_string_literal "a\"b"));
+
+      "backslash is escaped" >:: (fun _ ->
+        assert_equal ~printer:(fun x -> x) "a\\\\b" (escape_string_literal "a\\b"));
+
+      "newline becomes backslash-n" >:: (fun _ ->
+        assert_equal ~printer:(fun x -> x) "a\\nb" (escape_string_literal "a\nb"));
+
+      "tab becomes backslash-t" >:: (fun _ ->
+        assert_equal ~printer:(fun x -> x) "a\\tb" (escape_string_literal "a\tb"));
+
+      "plain ASCII is unchanged" >:: (fun _ ->
+        assert_equal ~printer:(fun x -> x) "hello" (escape_string_literal "hello"));
+    ]
+
+let _ = run_test_tt_main tests


### PR DESCRIPTION
## Summary

Hardens the `-inverse` (program inversion) path so its output always re-parses
to the same program, adds convenient integer-literal forms, and substantially
expands the test suite (a reversible language had no end-to-end parse→eval or
reversibility-law coverage before).

## `-inverse` / pretty-printer correctness

- **Parenthesize nested arithmetic.** `pretty_exp` printed binary operators
  flat, so grouping was lost: `i * ((a + k) / i)` became `i * a + k / i`, a
  different value. A binary operand that is itself a binary expression is now
  wrapped in parentheses. `( e )` is discarded by the parser, so
  `parse (pretty p) = p` still holds.
- **Escape control bytes.** Control bytes (`< 0x20`) and DEL are now emitted as
  `\DDD` instead of raw (a raw ESC injected an ANSI sequence into `-inverse`
  output; a raw NUL corrupted regenerated source). `lexer.mll` gains a matching
  `\DDD` string escape. UTF-8 bytes (`>= 0x80`, e.g. Japanese) still pass
  through verbatim and re-parse, continuing the non-ASCII fix.

## New integer literals (lexer only)

Hex `0xFF`, binary `0b1010`, and char `'A'` literals. All lex to a plain
`CONST`, so the parser, evaluator, inverter and pretty-printer are unchanged;
they pretty-print back as decimal (AST round-trips, surface form not preserved,
matching how `-e` prints as `0 - e`). Char supports `\n \t \\ \' \"`, single-byte
ASCII only, and coexists with prime identifiers (`x'`).

## Tests

- Involution `invert (invert s) = s` over every statement (incl. the Switch
  fall-through rewrite).
- Runtime reversibility: `eval_state (s @ invert s)` restores the store.
- New end-to-end `parse → eval_prog` suite (the only coverage of lexer/parser),
  with regression cases for the parenthesization, control-byte/non-ASCII print,
  and the new literals.
- `test/Makefile` builds `../src` once via a shared order-only prerequisite
  instead of once per suite.

## Verification

- All suites green.
- parse → pretty → parse over all 139 `example/*.rplpp` programs: 139 ok, 0
  mismatch, 0 error.