### PR TITLE
Reject aliased reference arguments (found by porting PyJanus's error fixtures)

### DIFF
--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -340,18 +340,26 @@ let rec eval_state stml env map st0 =
        in
        let st2 = ext_st st lvx v' (* the right value of x *) in
        (* 可逆性の副条件。整数変数への代入は構文的に（coq/roopl.v の E_assign の
-          x ∉ fv(e)）、フィールドと配列要素は意味的に（E_fassign / E_aassign の
-          eval e b = eval e a）検査する。後者は別名を構文で近似せずに済む *)
+          x ∉ fv(e)）検査する。 *)
        (match y with
         | VarArray(x, None) ->
            if List.mem x (free_vars e) then
              fail_stm (pretty_stms [stm] 0 ^ "\nERROR:Variable " ^ x ^
                          " must not occur on both sides of this assignment")
-        | _ ->
-           if eval_exp e env st2 <> v then
-             fail_stm (pretty_stms [stm] 0 ^
-                         "\nERROR:The right-hand side of this assignment must not be \
-                          changed by the assignment itself"));
+        | _ -> ());
+       (* 右辺が自分の書き込みで変わらないこと（E_fassign / E_aassign の
+          eval e b = eval e a）。フィールドと配列要素はこれが本来の副条件で、
+          別名を構文で近似せずに済む。
+
+          **整数変数にもこれを掛ける。** 名前が違っても同じ場所を指しうるため:
+          call q(x, x) のように同じ変数を 2 つの仮引数へ参照渡しすると、本体の
+          a += b は名前の上では別物なのに実質 x += x になる。形式側は
+          bind_args が仮引数を実引数の名前へ置き換えるので構文的な条件で
+          弾けるが、実装は名前ではなくロケーションで束ねるので、値で見るしかない *)
+       if eval_exp e env st2 <> v then
+         fail_stm (pretty_stms [stm] 0 ^
+                     "\nERROR:The right-hand side of this assignment must not be \
+                      changed by the assignment itself");
        check_locs_stable st2 [ (y, lvx) ];
        st2
     (*SWPVAR*) (*SWAPARRVAR*)

--- a/python/rooplpp/eval.py
+++ b/python/rooplpp/eval.py
@@ -469,8 +469,7 @@ def _update(stm: Stm, env: Env, map_: list, st: State) -> State:
                 raise StmError(pretty_stms([stm], 0) + "\nERROR:Integer value expected in this statement")
             st2 = ext_st(st, lvx, v2)
             # 可逆性の副条件。整数変数への代入は構文的に（coq/roopl.v の E_assign の
-            # x ∉ fv(e)）、フィールドと配列要素は意味的に（E_fassign / E_aassign の
-            # eval e b = eval e a）検査する。後者は別名を構文で近似せずに済む
+            # x ∉ fv(e)）検査する
             match y:
                 case VarArray(x, None):
                     if x in free_vars(e):
@@ -479,11 +478,17 @@ def _update(stm: Stm, env: Env, map_: list, st: State) -> State:
                             + f"\nERROR:Variable {x} must not occur on both sides"
                               " of this assignment")
                 case _:
-                    if eval_exp(e, env, st2) != v:
-                        raise StmError(
-                            pretty_stms([stm], 0)
-                            + "\nERROR:The right-hand side of this assignment must not be"
-                              " changed by the assignment itself")
+                    pass
+            # 右辺が自分の書き込みで変わらないこと（E_fassign / E_aassign の
+            # eval e b = eval e a）。**整数変数にも掛ける**: 名前が違っても同じ
+            # 場所を指しうる（call q(x, x) のような参照渡しの別名。形式側は
+            # bind_args の改名で構文的に弾けるが、実装はロケーションで束ねるので
+            # 値で見るしかない）
+            if eval_exp(e, env, st2) != v:
+                raise StmError(
+                    pretty_stms([stm], 0)
+                    + "\nERROR:The right-hand side of this assignment must not be"
+                      " changed by the assignment itself")
             check_locs_stable(st2, [(y, lvx)])
             return st2
 

--- a/python/tests/test_errors.py
+++ b/python/tests/test_errors.py
@@ -64,6 +64,16 @@ CASES = [
      "must not mention the loop variable",
      prog("  local int i = 0\n  for i in (i..3) do\n   x += 1\n  end\n"
           "  delocal int i = 0\n")),
+    # 参照渡しの別名（PyJanus の alias-1 / alias-2 に相当）。同じ変数を 2 つの
+    # 仮引数へ渡すと名前は違っても同じ場所を指し、本体の a += b が実質 x += x になる
+    ("the same variable passed to two reference parameters",
+     "must not be changed by the assignment itself",
+     "class Program\n int x\n method bump(int a, int b)\n  a += b\n"
+     " method main()\n  x += 5\n  call bump(x, x)\n"),
+    ("the same array passed to two reference parameters",
+     "must not be changed by the assignment itself",
+     "class Program\n int[] a\n method bump(int[] p, int[] q)\n  p[1] += q[1]\n"
+     " method main()\n  new int[3] a\n  a[1] += 4\n  call bump(a, a)\n"),
     ("division by zero", "division by zero", prog("  x += 1 / y\n")),
     ("modulo by zero", "modulo by zero", prog("  x += 1 % y\n")),
     ("conditional exit assertion (then)", "Assertion should be true",
@@ -117,6 +127,10 @@ CONTROLS = [
     ("assignment reading another cell",
      prog("  new int[2] a\n  a[1] += 5\n  a[0] += a[1]\n  a[0] -= 5\n  a[1] -= 5\n"
           "  delete int[2] a\n")),
+    # 別名でも壊れない本体は通る（同一セルの swap は恒等）
+    ("aliased call whose body is a self-swap",
+     "class Program\n int x\n method sw(int a, int b)\n  a <=> b\n"
+     " method main()\n  x += 5\n  call sw(x, x)\n  x -= 5\n"),
     ("assignment whose index mentions a variable",
      prog("  new int[2] a\n  x += 1\n  a[x] += x\n  a[x] -= 1\n  x -= 1\n"
           "  delete int[2] a\n")),

--- a/test/error_test.ml
+++ b/test/error_test.ml
@@ -92,6 +92,21 @@ let suite = "test suite for runtime error paths" >::: [
     (prog "  local int i = 0\n  for i in (i..3) do\n   x += 1\n  end\n"
      ^ "  delocal int i = 0\n");
 
+  (* ---- 参照渡しの別名（PyJanus の alias-1 / alias-2 に相当） ----------
+     同じ変数を 2 つの仮引数へ渡すと、名前は違っても同じ場所を指す。本体の
+     `a += b` は実質 `x += x` で、逆向きに戻せない（uncall しても元へ戻らない）。
+     形式側は bind_args が仮引数を実引数の名前へ置き換えるので構文的な副条件で
+     弾けるが、実装はロケーションで束ねるので値で見る *)
+  case "the same variable passed to two reference parameters"
+    "must not be changed by the assignment itself"
+    ("class Program\n int x\n method bump(int a, int b)\n  a += b\n"
+     ^ " method main()\n  x += 5\n  call bump(x, x)\n");
+
+  case "the same array passed to two reference parameters"
+    "must not be changed by the assignment itself"
+    ("class Program\n int[] a\n method bump(int[] p, int[] q)\n  p[1] += q[1]\n"
+     ^ " method main()\n  new int[3] a\n  a[1] += 4\n  call bump(a, a)\n");
+
   (* ---- 算術 -------------------------------------------------------- *)
   case "division by zero" "division by zero"
     (prog "  x += 1 / y\n");
@@ -224,6 +239,12 @@ let suite = "test suite for runtime error paths" >::: [
   "control: an assignment reading another cell raises nothing" >:: (fun _ ->
     assert_ok (prog ("  new int[2] a\n  a[1] += 5\n  a[0] += a[1]\n"
                      ^ "  a[0] -= 5\n  a[1] -= 5\n  delete int[2] a\n")));
+
+  (* 別名でも壊れない本体は通る。形式側も同じ（同一セルの swap は恒等）ので、
+     「別名だから一律に拒否」ではなく「壊れるときだけ拒否」になっている *)
+  "control: an aliased call whose body is a self-swap raises nothing" >:: (fun _ ->
+    assert_ok ("class Program\n int x\n method sw(int a, int b)\n  a <=> b\n"
+               ^ " method main()\n  x += 5\n  call sw(x, x)\n  x -= 5\n"));
 
   "control: an assignment whose index mentions a variable raises nothing" >:: (fun _ ->
     assert_ok (prog ("  new int[2] a\n  x += 1\n  a[x] += x\n"

--- a/test/extracted_test.ml
+++ b/test/extracted_test.ml
@@ -347,6 +347,34 @@ let menv_bump : R.menv =
 let methods_bump =
   [ MDecl ("m0", [ Decl (IntegerType, "v3") ], [ Assign (VarArray ("v3", None), ModAdd, Const 1) ]) ]
 
+(* 同じ変数を 2 つの仮引数へ参照渡しする（PyJanus の alias-1 に相当）。
+   形式側は bind_args が仮引数を実引数の名前へ置き換えるので、本体 v3 += v4 は
+   v0 += v0 になり E_assign の x ∉ fv(e) で弾かれる。
+   本体が別名で壊れないもの（swap は同一セルなら恒等）は通ってよい。 *)
+let addto_self_body = R.Sassign (v 3, R.MAdd, R.Var (v 4))
+let menv_alias : R.menv =
+  { R.procs = (fun m -> if int_of_nat m = 2
+                        then Some (R.MDecl ([ v 3; v 4 ], addto_self_body))
+                        else if int_of_nat m = 3
+                        then Some (R.MDecl ([ v 3; v 4 ], R.Sswap (v 3, v 4)))
+                        else None);
+    R.classes = (fun _ -> None); R.cells = cells_of }
+let methods_alias =
+  [ MDecl ("m2", [ Decl (IntegerType, "v3"); Decl (IntegerType, "v4") ],
+           [ Assign (VarArray ("v3", None), ModAdd, Var "v4") ]);
+    MDecl ("m3", [ Decl (IntegerType, "v3"); Decl (IntegerType, "v4") ],
+           [ Swap (VarArray ("v3", None), VarArray ("v4", None)) ]) ]
+
+(* 別名で壊れる本体（v3 += v4 が v0 += v0 になる） *)
+let p_alias_add =
+  R.Sseq (R.Sassign (v 0, R.MAdd, c 5),
+          R.Scall (nat_of_int 2, [ R.Aref (v 0); R.Aref (v 0) ]))
+
+(* 別名でも壊れない本体（同一セルの swap は恒等） *)
+let p_alias_swap =
+  R.Sseq (R.Sassign (v 0, R.MAdd, c 5),
+          R.Scall (nat_of_int 3, [ R.Aref (v 0); R.Aref (v 0) ]))
+
 let p_call = R.Scall (nat_of_int 0, [ R.Aref (v 0) ])
 let p_call_uncall = R.Sseq (R.Scall (nat_of_int 0, [ R.Aref (v 0) ]),
                             R.Suncall (nat_of_int 0, [ R.Aref (v 0) ]))
@@ -749,6 +777,20 @@ let suite = "test suite for the extracted verified interpreter" >::: [
         assert_equal ~printer None (run_verified p_local_self_exit [ 0 ]);
         assert_equal ~printer None (run_verified p_local_self_entry [ 0 ]));
       agree "nested loop and local block" p_nested [ 0 ];
+      (* 同じ変数を 2 つの仮引数へ渡す（別名）。本体が別名で壊れるかどうかで
+         結果が分かれることを、両エンジンで一致させる *)
+      agree ~env:menv_alias ~methods:methods_alias
+        "an aliased call whose body would double the variable is rejected"
+        p_alias_add [ 0 ];
+      agree ~env:menv_alias ~methods:methods_alias
+        "an aliased call whose body is a self-swap is fine"
+        p_alias_swap [ 0 ];
+
+      "the formal side rejects only the harmful aliasing" >:: (fun _ ->
+        assert_equal ~printer None (run_verified ~env:menv_alias p_alias_add [ 0 ]);
+        assert_equal ~printer (Some [ 5 ])
+          (run_verified ~env:menv_alias p_alias_swap [ 0 ]));
+
       agree ~env:menv_bump ~methods:methods_bump "call" p_call [ 0 ];
       agree ~env:menv_bump ~methods:methods_bump "call then uncall" p_call_uncall [ 0 ];
 


### PR DESCRIPTION
姉妹プロジェクト **PyJanus** のエラーフィクスチャ 52 本を棚卸しして、ROOPL++ に
同じ概念があるものを移植した。**可逆性のバグが 1 件見つかったので直す。**

## 見つけたバグ: 参照渡しの別名

同じ変数を 2 つの仮引数へ渡すと往復しない。

```
method bump(int a, int b)
    a += b

x += 5
call bump(x, x)      // x = 10 になっていた
uncall bump(x, x)    // 戻らない
x -= 5               // x = -5
```

名前は違っても**同じ場所を指す**ので、本体の `a += b` は実質 `x += x`。実装は
代入の副条件を整数変数については**構文的にだけ**（`x ∉ fv(e)`）検査していたので、
名前が違うこの形をすり抜けていた。配列を 2 つの仮引数へ渡す形（`p[1] += q[1]`）も
同じ。

### 形式側は最初から弾いている

`coq/roopl.v` の `bind_args` は仮引数を実引数の名前へ置き換えるので、本体は
`v0 += v0` になり `E_assign` の副条件で導出が無くなる。差分テストを足したところ
**実装は `[10]`、`run` は `None`** と食い違いを示した。

### 修正

「右辺が自分の書き込みで変わらないこと」（`E_fassign` / `E_aassign` の
`eval e b = eval e a`）の検査を**整数変数にも掛ける**。実装は名前ではなく
ロケーションで束ねるので、別名は値で見るしかない。

これで形式側と一致する——**別名だから一律に拒否するのではなく、壊れるときだけ
拒否する**。同一セルの swap は恒等なので両方で通ることも差分テストで固定した
（`agree` 2 本 + `run` 側の期待値 2 本）。

## 52 本の棚卸し結果

| 分類 | 本数 |
|---|---|
| 既に ROOPL++ で検査済み（表明・範囲外・ゼロ除算・未定義変数ほか） | 14 |
| **移植してバグ発見** — `alias-1`, `alias-2` | 2 |
| 概念はあるが静的検査が無い（下記） | 5 |
| ROOPL++ に概念が無い（stack 5 / printf 5 / 静的型 8 / `assert` / `modular` ほか） | 31 |

**この PR には含めていないもの**（可逆性は壊さず、修正は新機能にあたるため）:
同名メソッド・同名フィールド・同名の仮引数・`main` の重複はいずれも黙って受理
される（先に書いた方が使われる）。`main` に引数を付けると `unbound variable` で
落ちるが分かりにくい。`new int[0]` は内部的な `index out of bounds in lookup_vec`
というメッセージになる。

## 反省

PyJanus は `alias-1` / `alias-2` / `var-modified-on-rhs` / `var-modified-on-lhs` /
`vjanus-delocal-self-ref` として、これらを最初から持っていた。**姉妹プロジェクトの
テストを先に見ていれば、今回見つけた 6 件のうち 4 件は最初から分かっていた。**

## 検証済みのこと

- [x] `dune test --force` 18 スイート全通過（手元・opam / OCaml 5.x）
      — error 48 件・差分 73 件・例題 360 件
- [x] `python3 -m pytest -q` 233 件全通過（手元・Python 3.14）
- [x] 差分テストで形式側と一致（壊れる別名は両方 `None`、自己 swap は両方成功）
- [x] gitleaks クリーン
