### PR TITLE
Four more reversibility/correctness bugs, and a sweep test that finds them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ web/dist
 __pycache__/
 *.pyc
 .pytest_cache/
+
+# bisect_ppx のカバレッジ生成物
+*.coverage

--- a/example/objectArrayIndexScope.rplpp
+++ b/example/objectArrayIndexScope.rplpp
@@ -1,0 +1,33 @@
+// ドットの右側の添字は「呼び出し側」のスコープで解決する。
+// Box も Program も k を持つが、b.xs[k] の k は Program の k (= 1) である。
+// b.xs = [100, 200, 300] なので r = 200 になる（内側の k = 2 を使うと 300）。
+class Box
+    int[] xs
+    int k
+    method init()
+        new int[3] xs
+        k += 2
+        xs[0] += 100
+        xs[1] += 200
+        xs[2] += 300
+    method fin()
+        xs[0] -= 100
+        xs[1] -= 200
+        xs[2] -= 300
+        k -= 2
+        delete int[3] xs
+
+class Program
+    int r
+    int k
+    Box b
+    method main()
+        new Box b
+        call b::init()
+        k += 1
+        r += b.xs[k]
+        b.xs[k] += 5
+        b.xs[k] -= 5
+        k -= 1
+        call b::fin()
+        delete Box b

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -598,7 +598,15 @@ let rec eval_state stml env map st0 =
          | Failure str -> fail_stm (pretty_stms [stm] 0 ^ "\n" ^ str ^ " in this statement") in
        let locs, _ = lval_val obj env in                    (* l=γ(y) *)
        let locs0 = match lookup_st locs st with LocsVal(l) -> l | _ -> failwith "ERROR:delete needs an allocated object, but the variable is nil or not an object" in
-       let envf = match lookup_st locs0 st with ObjVal(_, e) -> e | _ -> failwith "ERROR:delete needs an allocated object, but the variable does not refer to one" in
+       let acls, envf = match lookup_st locs0 st with
+         | ObjVal(c, e) -> c, e
+         | _ -> failwith "ERROR:delete needs an allocated object, but the variable does not refer to one" in
+       (* 解放するクラスが実際のクラスと一致すること（coq/roopl.v の E_delete /
+          E_obj の hc a l = cl）。これが無いと、フィールド数の違うクラス名で
+          delete したときに消すロケーション数がずれてストアが壊れる *)
+       if acls <> tid then
+         fail_stm (pretty_stms [stm] 0 ^ "\nERROR:This deletes a " ^ acls ^
+                     " as if it were a " ^ tid ^ "; the class must match in this statement");
        let locs1 = if List.length envf = 0 then 0
                    else List.hd (List.map snd envf) in      (* locs1=l1 *)
        if is_field_zero st locs1 (List.length fl) then      (* インスタンスフィールドがゼロクリアされているか確認 *)

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -4,8 +4,6 @@ open Value
 open Pretty
 open Invert
 
-let myassert (cond, msg) = if not cond then failwith msg
-
 (**すでに「どの文で起きたか」を含む実行時エラーを投げる。
    Failure ではなく Util.Runtime_error を使うことで、文を包むラッパが
    同じ文を二重に付けないようにする。 *)
@@ -76,31 +74,41 @@ let comp_op f v1 v2 = IntVal(if f v1 v2 then 1 else 0)
 
 (**式expressionを評価するための関数：環境、ストアを受け取り、値を返す．*)
 let rec eval_exp exp env st =
-  let rec lval_val y env =
+  (* [ienv] は**添字の式**を評価する環境。名前の解決 [env] とは別に持ち回る:
+     ドットの右側（o.xs[i]）では、フィールド名 xs はオブジェクト側の環境で
+     引くが、添字 i は呼び出し側のスコープの変数である。両方を env' にすると
+     o.xs[k] の k がオブジェクトのフィールド k を指してしまう *)
+  let rec lval_val_in ienv y env =
     match strip_epos y with
     | Var(x) -> let lv = lookup_envs x env in lv, lookup_st lv st
     | ArrayElement(x, e) ->
-       let x_index = match eval_exp e env st with
+       let x_index = match eval_exp e ienv st with
          | IntVal(n) -> n
          | _ -> failwith "ERROR:array index must be an integer" in
        let locsvecx = match lookup_val x env st with
          | LocsVec(v) -> v
          | _ -> failwith "ERROR:expected array value" in
-       let locsx' = lookup_vec x_index locsvecx in
+       let locsx' =
+         if x_index >= 0 && x_index < List.length locsvecx
+         then x_index + List.hd locsvecx
+         else failwith ("ERROR:Array index " ^ x ^ "[" ^ string_of_int x_index
+                        ^ "] is out of bounds in this statement") in
        let v = lookup_st locsx' st in
        locsx', v
     | Dot(x, xi) ->
-       let _, locs = lval_val x env in
+       let _, locs = lval_val_in ienv x env in
        (match locs with
        | LocsVal(l)->
           (match lookup_st l st with
             | ObjVal(_c, env') ->
-               let li, v = lval_val xi env' in
+               (* 名前は env' で引くが、添字は ienv のまま *)
+               let li, v = lval_val_in ienv xi env' in
                li, v
             | _ -> failwith "ERROR:expected object value for dot access")
        | _ -> failwith "ERROR:expected location value for dot access")
     | _ -> failwith "ERROR:not an l-value expression"
   in
+  let lval_val y env = lval_val_in env y env in
   match exp with
   (* 位置つきの式：中で落ちたらいちばん内側の位置を例外に載せる *)
   | EPos(p, e) ->
@@ -252,11 +260,11 @@ let rec eval_state stml env map st0 =
     (* y (= x or x[n] or y.y) を受けとりそのロケーションと値を返す。
         ストアを引数に取るのは、書き込んだ後の状態でもう一度解決して
         「l 値が自分の書き込みで動いていないか」を確かめるため *)
-    let rec lval_val_in st y env =
+    let rec lval_val_in ?(ienv = env) st y env =
     match y with
     | VarArray(x, None) -> let lv = lookup_envs x env in lv, lookup_st lv st
     | VarArray(x, Some e) ->
-       let x_index = match eval_exp e env st with
+       let x_index = match eval_exp e ienv st with
          | IntVal(n) -> n
          | _ -> failwith "ERROR:array index must be an integer" in
        let locsvecx = match lookup_val x env st with
@@ -270,12 +278,13 @@ let rec eval_state stml env map st0 =
        let v = lookup_st locsx' st in (*the value of x[e1]*)
        locsx', v
     | InstVar(x, xi) ->
-       let _, locs = lval_val_in st x env in
+       let _, locs = lval_val_in ~ienv st x env in
        (match locs with
          LocsVal(l) ->
           (match lookup_st l st with
             | ObjVal(_c, env') ->
-               let li, v = lval_val_in st xi env' in
+               (* 名前は env' で引くが、添字は呼び出し側の ienv のまま *)
+               let li, v = lval_val_in ~ienv st xi env' in
                li, v
             | _ -> failwith "ERROR:expected object value for instance variable access")
        | _ -> failwith "ERROR:expected location value for instance variable access")

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -294,6 +294,16 @@ let rec eval_state stml env map st0 =
         coq/roopl.v の E_aassign / E_aswap の前提「eval ei b = eval ei a」
         （添字が自分の書き込みで変わらない）にあたる。添字を含まない l 値は
         動きようがないので調べない *)
+    (* copy / uncopy の両辺が同じ変数でないこと。ロケーションで比べるので、
+       別の変数が同じオブジェクトを指す（uncopy の正当な使い方）は通る *)
+    let check_not_same_var o1 o2 =
+      let l1, _ = lval_val_in st o1 env in
+      let l2, _ = lval_val_in st o2 env in
+      if l1 = l2 then
+        fail_stm (pretty_stms [stm] 0 ^
+                    "\nERROR:copy and uncopy need two different variables; \
+                     uncopy of a variable with itself would erase its value")
+    in
     let check_locs_stable st' targets =
       List.iter
         (fun (y, lv) ->
@@ -626,6 +636,11 @@ let rec eval_state stml env map st0 =
          fail_stm (pretty_stms [stm] 0 ^ "\nERROR:All array elements is not zero-cleared in this statement")
     (*COPY*)
     | CopyReference(_dt, obj1, obj2) ->      (* copy c x x' *)
+       (* 同じ変数どうしは禁止（coq/roopl.v の E_copy / E_uncopy の x ≠ y）。
+          uncopy x x は値を消してしまい逆向きに戻せない。別の変数が同じ
+          オブジェクトを指すのは uncopy の正当な使い方なので、値ではなく
+          **ロケーション**で比べる *)
+       check_not_same_var obj1 obj2;
        let locsx',v = lval_val obj2 env in  (* v=μ(γ(x)) *)
        if v <> IntVal(0) then               (* x'がnilか確認 *)
          fail_stm (pretty_stms [stm] 0 ^ "\nERROR:variable of right is not nil in this statement")
@@ -634,6 +649,7 @@ let rec eval_state stml env map st0 =
        ext_st st locsx' vx                  (* ストア更新μ[l'->v] *)
     (*UNCOPY*)
     | UncopyReference(_dt, obj1, obj2) -> (* uncopy c x x' *)
+       check_not_same_var obj1 obj2;
        let _, v1 = lval_val obj1 env in (* 変数xの値を求める *)
        let locs, v2 = lval_val obj2 env in (* 変数x'の値を求める *)
        if v1 = v2 then                   (* 同じ領域を指しているか確認 *)

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -104,8 +104,8 @@ let rec eval_exp exp env st =
                (* 名前は env' で引くが、添字は ienv のまま *)
                let li, v = lval_val_in ienv xi env' in
                li, v
-            | _ -> failwith "ERROR:expected object value for dot access")
-       | _ -> failwith "ERROR:expected location value for dot access")
+            | _ -> failwith "ERROR:Field access needs an object on the left of the dot, but it holds no object here")
+       | _ -> failwith "ERROR:Field access needs an object on the left of the dot, but the value is nil or an integer")
     | _ -> failwith "ERROR:not an l-value expression"
   in
   let lval_val y env = lval_val_in env y env in
@@ -217,7 +217,7 @@ let lookup_meth x vl meth =
 (**マップのリストから指定されたクラス名のfieldとメソッドのタプルを返す*)
 let lookup_map id map =
   try snd (List.find (fun (x , _) -> x = id) map)
-  with Not_found -> failwith ("ERROR:class " ^ id ^ " is not valid")
+  with Not_found -> failwith ("ERROR:Class " ^ id ^ " is not declared in this program")
 
 (**環境に指定されたメソッドのフィールドを使われていないロケーションに追加する．eval_stateのOBJBLOKで使用*)
 let rec ext_env_field f n =
@@ -286,8 +286,8 @@ let rec eval_state stml env map st0 =
                (* 名前は env' で引くが、添字は呼び出し側の ienv のまま *)
                let li, v = lval_val_in ~ienv st xi env' in
                li, v
-            | _ -> failwith "ERROR:expected object value for instance variable access")
-       | _ -> failwith "ERROR:expected location value for instance variable access")
+            | _ -> failwith "ERROR:Field access needs an object on the left of the dot, but it holds no object here")
+       | _ -> failwith "ERROR:Field access needs an object on the left of the dot, but the value is nil or an integer")
     in
     let lval_val y env = lval_val_in st y env in
     (* 書き込みで l 値のロケーションが動いていないことを確認する。
@@ -528,22 +528,22 @@ let rec eval_state stml env map st0 =
     (*LocalCALL*)
     | LocalCall(_mid, _args) (* call q(y1,...,yn) *)->
        let locs = lookup_envs "this" env in                   (* γ(this) = l *)
-       let locs2 = match lookup_st locs st with LocsVal(l) -> l | _ -> failwith "ERROR:expected location value for 'this'" in
+       let locs2 = match lookup_st locs st with LocsVal(l) -> l | _ -> failwith "ERROR:The receiver of this call is nil or not an object" in
        mycall locs locs2 0
     (*LocalUNCALL*)
     | LocalUncall(_mid, _args) (* uncall q(y1,...,yn) *)->
        let locs = lookup_envs "this" env in                   (* γ(this) = l *)
-       let locs2 = match lookup_st locs st with LocsVal(l) -> l | _ -> failwith "ERROR:expected location value for 'this'" in
+       let locs2 = match lookup_st locs st with LocsVal(l) -> l | _ -> failwith "ERROR:The receiver of this call is nil or not an object" in
        mycall locs locs2 1
     (*CALLOBJ*)
     | ObjectCall(obj, _mid, _args) (* call x0::q(a1,...,an) *)->
        let locs, v = lval_val obj env in
-       let locs2 = match v with LocsVal(l) -> l | _ -> failwith "ERROR:expected location value for object call" in
+       let locs2 = match v with LocsVal(l) -> l | _ -> failwith "ERROR:The receiver of this call is nil or not an object" in
        mycall locs locs2 0
     (*UNCALLOBJ*)
     | ObjectUncall(obj, _mid, _args) (* uncall x0::q(a1,...,an) *)->
        let locs, v = lval_val obj env in
-       let locs2 = match v with LocsVal(l) -> l | _ -> failwith "ERROR:expected location value for object uncall" in
+       let locs2 = match v with LocsVal(l) -> l | _ -> failwith "ERROR:The receiver of this call is nil or not an object" in
        mycall locs locs2 1
     (*OBJBLOCK*)
     | ObjectBlock(tid, id, stml) (* construct c x  s destruct x *)->
@@ -587,8 +587,8 @@ let rec eval_state stml env map st0 =
        let (fl, _) = try lookup_map tid map with
          | Failure str -> fail_stm (pretty_stms [stm] 0 ^ "\n" ^ str ^ " in this statement") in
        let locs, _ = lval_val obj env in                    (* l=γ(y) *)
-       let locs0 = match lookup_st locs st with LocsVal(l) -> l | _ -> failwith "ERROR:expected location for object destruction" in
-       let envf = match lookup_st locs0 st with ObjVal(_, e) -> e | _ -> failwith "ERROR:expected object value for destruction" in
+       let locs0 = match lookup_st locs st with LocsVal(l) -> l | _ -> failwith "ERROR:delete needs an allocated object, but the variable is nil or not an object" in
+       let envf = match lookup_st locs0 st with ObjVal(_, e) -> e | _ -> failwith "ERROR:delete needs an allocated object, but the variable does not refer to one" in
        let locs1 = if List.length envf = 0 then 0
                    else List.hd (List.map snd envf) in      (* locs1=l1 *)
        if is_field_zero st locs1 (List.length fl) then      (* インスタンスフィールドがゼロクリアされているか確認 *)

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -19,7 +19,8 @@ let ext_st st x v = List.sort (fun x y -> compare (fst x) (fst y)) ((x,v) :: (Li
 
 (**eval_stateで使用：locsからn-1までのロケーションに対応する値をすべてIntVal(0)にする関数*)
 let rec ext_st_zero st locs n =
-  if n <> 0 then
+  (* n > 0 で止める（gen_locsvec と同じ理由） *)
+  if n > 0 then
     ext_st (ext_st_zero st (locs + 1) (n - 1)) locs (IntVal(0))
   else
     st
@@ -157,7 +158,8 @@ let rec eval_exp exp env st =
 
 (**ロケーションのベクトルを生成する関数：第一引数に要素数、第二引数に使われてないロケーションの場所を受け取る*)
 let rec gen_locsvec n locs =
-  if n <> 0 then locs :: gen_locsvec (n - 1) (locs + 1)
+  (* n > 0 で止める。n <> 0 だと負の要素数で無限再帰して Stack_overflow になる *)
+  if n > 0 then locs :: gen_locsvec (n - 1) (locs + 1)
   else []
 
 (** callの意味論の関数search_aに相当 *)
@@ -240,7 +242,7 @@ let rec eval_state stml env map st0 =
   let isTrue = function
     | IntVal(0) -> false
     | IntVal(_) -> true
-    | _ -> failwith "ERROR in isTrue" in
+    | _ -> failwith "ERROR:Integer value expected in the condition of this statement" in
   let isFalse x = not (isTrue x) in
   let f = function
     | ModAdd -> (+)
@@ -593,11 +595,17 @@ let rec eval_state stml env map st0 =
          fail_stm (pretty_stms [stm] 0 ^ "\nERROR:Variable is not nil in this statement")
        else
        let n = match eval_exp e env st with IntVal(n) -> n | _ -> failwith "ERROR:array size must be integer" in
+       if n < 1 then
+         fail_stm (pretty_stms [stm] 0 ^ "\nERROR:Array size must be at least 1, but it is "
+                   ^ string_of_int n ^ " in this statement");
        let st2 = ext_st st locs (LocsVec(gen_locsvec n (max_locs st + 1))) in (* ベクトルを生成({l'1,...,l'n}しストアに格納 *)
        ext_st_zero st2 (max_locs st2 + 1)  n                                  (* ストア拡張 μ[l'1->0,...,l'n->0 *)
     (*ARRDELETE*)
     | ArrayDestruction((_tid, e), obj) ->           (* delete a[e] x *)
        let n = match eval_exp e env st with IntVal(n) -> n | _ -> failwith "ERROR:array size must be integer" in
+       if n < 1 then
+         fail_stm (pretty_stms [stm] 0 ^ "\nERROR:Array size must be at least 1, but it is "
+                   ^ string_of_int n ^ " in this statement");
        let veclocs,_ = lval_val obj env in         (* l=γ(x) *)
        let vec = match lookup_st veclocs st with LocsVec(v) -> v | _ -> failwith "ERROR:expected array value for deletion" in
        let locs = lookup_vec 0 vec in              (* locs = l'1 *)

--- a/python/rooplpp/eval.py
+++ b/python/rooplpp/eval.py
@@ -354,7 +354,7 @@ def _update(stm: Stm, env: Env, map_: list, st: State) -> State:
         match v:
             case IntVal(0): return False
             case IntVal(_): return True
-            case _: raise RuntimeError("ERROR in isTrue")
+            case _: raise RuntimeError("ERROR:Integer value expected in the condition of this statement")
 
     def isFalse(v: Value) -> bool:
         return not isTrue(v)
@@ -647,12 +647,21 @@ def _update(stm: Stm, env: Env, map_: list, st: State) -> State:
             if v != IntVal(0):
                 raise StmError(pretty_stms([stm], 0) + "\nERROR:Variable is not nil in this statement")
             n = match_int(eval_exp(e, env, st), "array size must be integer")
+            # 要素数 0 以下は degenerate（OCaml 側は負で無限再帰していた）
+            if n < 1:
+                raise StmError(
+                    pretty_stms([stm], 0)
+                    + f"\nERROR:Array size must be at least 1, but it is {n} in this statement")
             ml_ = max_locs(st)
             st2 = ext_st(st, l, LocsVec(gen_locsvec(n, ml_ + 1)))
             return ext_st_zero(st2, max_locs(st2) + 1, n)
 
         case ArrayDestruction(tid, e, obj):
             n = match_int(eval_exp(e, env, st), "array size must be integer")
+            if n < 1:
+                raise StmError(
+                    pretty_stms([stm], 0)
+                    + f"\nERROR:Array size must be at least 1, but it is {n} in this statement")
             veclocs, _ = lval_val(obj, env)
             vec = match_locsvec(lookup_st(veclocs, st))
             l = lookup_vec(0, vec)

--- a/python/rooplpp/eval.py
+++ b/python/rooplpp/eval.py
@@ -119,24 +119,35 @@ def comp_op_eq(f, v1: Value, v2: Value) -> Value:
 # --- Expression evaluation ---
 
 def eval_exp(exp: Exp, env: Env, st: State) -> Value:
-    def lval_val(y: Exp, env: Env):
-        """Return (location, value) for an l-value expression."""
+    def lval_val(y: Exp, env: Env, ienv: Env | None = None):
+        """l 値のロケーションと値を返す。
+
+        ienv は**添字の式**を評価する環境。名前の解決 env とは別に持ち回る:
+        ドットの右側（o.xs[i]）ではフィールド名 xs をオブジェクト側の環境で
+        引くが、添字 i は呼び出し側のスコープの変数である。両方を env2 にすると
+        o.xs[k] の k がオブジェクトのフィールド k を指してしまう。"""
+        if ienv is None:
+            ienv = env
         match strip_epos(y):
             case Var(x):
                 lv = lookup_envs(x, env)
                 return lv, lookup_st(lv, st)
             case ArrayElement(x, e):
-                x_index = match_int(eval_exp(e, env, st), "array index must be an integer")
+                x_index = match_int(eval_exp(e, ienv, st), "array index must be an integer")
                 locsvecx = match_locsvec(lookup_val(x, env, st))
-                locsx = lookup_vec(x_index, locsvecx)
+                if not (0 <= x_index < len(locsvecx)):
+                    raise RuntimeError(
+                        f"ERROR:Array index {x}[{x_index}] is out of bounds in this statement")
+                locsx = x_index + locsvecx[0]
                 return locsx, lookup_st(locsx, st)
             case Dot(x, xi):
-                _, locs = lval_val(x, env)
+                _, locs = lval_val(x, env, ienv)
                 match locs:
                     case LocsVal(l):
                         match lookup_st(l, st):
                             case ObjVal(_, env2):
-                                return lval_val(xi, env2)
+                                # 名前は env2 で引くが、添字は ienv のまま
+                                return lval_val(xi, env2, ienv)
                             case _:
                                 raise RuntimeError("ERROR:expected object value for dot access")
                     case _:
@@ -366,15 +377,19 @@ def _update(stm: Stm, env: Env, map_: list, st: State) -> State:
             ModOp.ModXor: lambda a, b: a ^ b,
         }[op]
 
-    def lval_val_in(st_: State, y: Obj, env: Env) -> tuple[Locs, Value]:
+    def lval_val_in(st_: State, y: Obj, env: Env,
+                    ienv: Env | None = None) -> tuple[Locs, Value]:
         """l 値のロケーションと値を返す。ストアを引数に取るのは、書き込んだ後の
-        状態でもう一度解決して「l 値が自分の書き込みで動いていないか」を見るため。"""
+        状態でもう一度解決して「l 値が自分の書き込みで動いていないか」を見るため。
+        ienv は添字の式を評価する環境（eval_exp 側の lval_val と同じ理由）。"""
+        if ienv is None:
+            ienv = env
         match y:
             case VarArray(x, None):
                 lv = lookup_envs(x, env)
                 return lv, lookup_st(lv, st_)
             case VarArray(x, idx):
-                x_index = match_int(eval_exp(idx, env, st_), "array index must be an integer")
+                x_index = match_int(eval_exp(idx, ienv, st_), "array index must be an integer")
                 locsvecx = match_locsvec(lookup_val(x, env, st_))
                 if x_index >= 0 and x_index < len(locsvecx):
                     locsx = x_index + locsvecx[0]
@@ -383,12 +398,13 @@ def _update(stm: Stm, env: Env, map_: list, st: State) -> State:
                         pretty_stms([stm], 0) + f"\nERROR:Array index {x}[{x_index}] is out of bounds in this statement")
                 return locsx, lookup_st(locsx, st_)
             case InstVar(x, xi):
-                _, locs = lval_val_in(st_, x, env)
+                _, locs = lval_val_in(st_, x, env, ienv)
                 match locs:
                     case LocsVal(l):
                         match lookup_st(l, st_):
                             case ObjVal(_, env2):
-                                return lval_val_in(st_, xi, env2)
+                                # 名前は env2 で引くが、添字は ienv のまま
+                                return lval_val_in(st_, xi, env2, ienv)
                             case _:
                                 raise RuntimeError("ERROR:expected object value for instance variable access")
                     case _:

--- a/python/rooplpp/eval.py
+++ b/python/rooplpp/eval.py
@@ -661,8 +661,16 @@ def _update(stm: Stm, env: Env, map_: list, st: State) -> State:
                 lookup_st(l, st),
                 "delete needs an allocated object, but the variable is nil or not an object")
             match lookup_st(l0, st):
-                case ObjVal(_, envf):
-                    pass
+                case ObjVal(acls, envf):
+                    # 解放するクラスが実際のクラスと一致すること
+                    # （coq/roopl.v の E_delete の hc a l = cl）。これが無いと
+                    # フィールド数の違うクラス名で delete したときに消す
+                    # ロケーション数がずれてストアが壊れる
+                    if acls != tid:
+                        raise StmError(
+                            pretty_stms([stm], 0)
+                            + f"\nERROR:This deletes a {acls} as if it were a {tid};"
+                              " the class must match in this statement")
                 case _:
                     raise RuntimeError("ERROR:delete needs an allocated object, but the variable does not refer to one")
             l1 = list(envf.values())[0] if envf else 0

--- a/python/rooplpp/eval.py
+++ b/python/rooplpp/eval.py
@@ -413,6 +413,20 @@ def _update(stm: Stm, env: Env, map_: list, st: State) -> State:
     def lval_val(y: Obj, env: Env) -> tuple[Locs, Value]:
         return lval_val_in(st, y, env)
 
+    def check_not_same_var(o1: Obj, o2: Obj) -> None:
+        """copy / uncopy の両辺が同じ変数でないこと（coq/roopl.v の x ≠ y）。
+
+        uncopy x x は値を消してしまい逆向きに戻せない。別の変数が同じ
+        オブジェクトを指すのは uncopy の正当な使い方なので、値ではなく
+        ロケーションで比べる。"""
+        l1, _ = lval_val_in(st, o1, env)
+        l2, _ = lval_val_in(st, o2, env)
+        if l1 == l2:
+            raise StmError(
+                pretty_stms([stm], 0)
+                + "\nERROR:copy and uncopy need two different variables;"
+                  " uncopy of a variable with itself would erase its value")
+
     def check_locs_stable(st_: State, targets: list[tuple[Obj, Locs]]) -> None:
         """書き込みで l 値のロケーションが動いていないことを確認する。
 
@@ -691,6 +705,7 @@ def _update(stm: Stm, env: Env, map_: list, st: State) -> State:
             raise StmError(pretty_stms([stm], 0) + "\nERROR:All array elements is not zero-cleared in this statement")
 
         case CopyReference(dt, obj1, obj2):
+            check_not_same_var(obj1, obj2)
             locsx2, v = lval_val(obj2, env)
             if v != IntVal(0):
                 raise StmError(pretty_stms([stm], 0) + "\nERROR:variable of right is not nil in this statement")
@@ -698,6 +713,7 @@ def _update(stm: Stm, env: Env, map_: list, st: State) -> State:
             return ext_st(st, locsx2, vx)
 
         case UncopyReference(dt, obj1, obj2):
+            check_not_same_var(obj1, obj2)
             _, v1 = lval_val(obj1, env)
             l, v2 = lval_val(obj2, env)
             if v1 == v2:

--- a/python/rooplpp/eval.py
+++ b/python/rooplpp/eval.py
@@ -149,9 +149,9 @@ def eval_exp(exp: Exp, env: Env, st: State) -> Value:
                                 # 名前は env2 で引くが、添字は ienv のまま
                                 return lval_val(xi, env2, ienv)
                             case _:
-                                raise RuntimeError("ERROR:expected object value for dot access")
+                                raise RuntimeError("ERROR:Field access needs an object on the left of the dot, but it holds no object here")
                     case _:
-                        raise RuntimeError("ERROR:expected location value for dot access")
+                        raise RuntimeError("ERROR:Field access needs an object on the left of the dot, but the value is nil or an integer")
             case _:
                 raise RuntimeError("ERROR:not an l-value expression")
 
@@ -320,7 +320,7 @@ def lookup_map(id: str, map_: list) -> tuple:
     for cid, fm in map_:
         if cid == id:
             return fm
-    raise RuntimeError(f"ERROR:class {id} is not valid")
+    raise RuntimeError(f"ERROR:Class {id} is not declared in this program")
 
 
 def ext_env_field(fields: list[Decl], n: int) -> Env:
@@ -406,9 +406,9 @@ def _update(stm: Stm, env: Env, map_: list, st: State) -> State:
                                 # 名前は env2 で引くが、添字は ienv のまま
                                 return lval_val_in(st_, xi, env2, ienv)
                             case _:
-                                raise RuntimeError("ERROR:expected object value for instance variable access")
+                                raise RuntimeError("ERROR:Field access needs an object on the left of the dot, but it holds no object here")
                     case _:
-                        raise RuntimeError("ERROR:expected location value for instance variable access")
+                        raise RuntimeError("ERROR:Field access needs an object on the left of the dot, but the value is nil or an integer")
 
     def lval_val(y: Obj, env: Env) -> tuple[Locs, Value]:
         return lval_val_in(st, y, env)
@@ -643,12 +643,14 @@ def _update(stm: Stm, env: Env, map_: list, st: State) -> State:
             except RuntimeError as e:
                 raise StmError(pretty_stms([stm], 0) + "\n" + str(e) + " in this statement")
             l, _ = lval_val(obj, env)
-            l0 = match_locsval(lookup_st(l, st))
+            l0 = match_locsval(
+                lookup_st(l, st),
+                "delete needs an allocated object, but the variable is nil or not an object")
             match lookup_st(l0, st):
                 case ObjVal(_, envf):
                     pass
                 case _:
-                    raise RuntimeError("ERROR:expected object value for destruction")
+                    raise RuntimeError("ERROR:delete needs an allocated object, but the variable does not refer to one")
             l1 = list(envf.values())[0] if envf else 0
             if is_field_zero(st, l1, len(fl)):
                 st2 = st
@@ -723,10 +725,11 @@ def _update(stm: Stm, env: Env, map_: list, st: State) -> State:
                 f"\nERROR: Variable {name} = {Printer.show_val(lookup_st(l, st3))}, But it should be {Printer.show_val(v2)} in this statement")
 
 
-def match_locsval(v: Value) -> Locs:
+def match_locsval(v: Value, msg: str = "The receiver of this call is nil or not an object") -> Locs:
+    """オブジェクト参照を取り出す。msg は文脈ごとに変える（OCaml 側と同じ文面）。"""
     match v:
         case LocsVal(l): return l
-        case _: raise RuntimeError("ERROR:expected location value for 'this'")
+        case _: raise RuntimeError(f"ERROR:{msg}")
 
 
 # --- Switch evaluator ---

--- a/python/tests/test_errors.py
+++ b/python/tests/test_errors.py
@@ -75,6 +75,9 @@ CASES = [
      prog("  new int[2] a\n  if a then\n   skip\n  fi a\n")),
     ("a loop condition that is not an integer", "Integer value expected in the condition",
      prog("  new int[2] a\n  from a loop\n   skip\n  until a\n")),
+    # ドットの右側の添字は呼び出し側のスコープで解決する
+    ("an out-of-bounds index through a field", "Array index xs[5] is out of bounds",
+     "class Box\n int[] xs\n int k\n method init()\n  new int[3] xs\n  k += 2\n  xs[0] += 100\n  xs[1] += 200\n  xs[2] += 300\n\nclass Program\n int r\n int k\n Box b\n method main()\n  new Box b\n  call b::init()\n  k += 1\n  r += b.xs[5]\n"),
     ("division by zero", "division by zero", prog("  x += 1 / y\n")),
     ("modulo by zero", "modulo by zero", prog("  x += 1 % y\n")),
     ("conditional exit assertion (then)", "Assertion should be true",

--- a/python/tests/test_errors.py
+++ b/python/tests/test_errors.py
@@ -83,6 +83,11 @@ CASES = [
      "class Box\n int f\n method noop()\n  skip\n\nclass Program\n int x\n method main()\n  x += x.f\n"),
     ("delete on a nil object", "delete needs an allocated object",
      "class Box\n int f\n method noop()\n  skip\n\nclass Program\n Box b\n method main()\n  delete Box b\n"),
+    ("uncopy of an integer variable with itself", "two different variables",
+     prog("  x += 1\n  uncopy int x x\n")),
+    ("uncopy of an object with itself", "two different variables",
+     "class Box\n int f\n method noop()\n  skip\n\n"
+     "class Program\n Box b\n method main()\n  new Box b\n  uncopy Box b b\n"),
     ("division by zero", "division by zero", prog("  x += 1 / y\n")),
     ("modulo by zero", "modulo by zero", prog("  x += 1 % y\n")),
     ("conditional exit assertion (then)", "Assertion should be true",

--- a/python/tests/test_errors.py
+++ b/python/tests/test_errors.py
@@ -78,6 +78,11 @@ CASES = [
     # ドットの右側の添字は呼び出し側のスコープで解決する
     ("an out-of-bounds index through a field", "Array index xs[5] is out of bounds",
      "class Box\n int[] xs\n int k\n method init()\n  new int[3] xs\n  k += 2\n  xs[0] += 100\n  xs[1] += 200\n  xs[2] += 300\n\nclass Program\n int r\n int k\n Box b\n method main()\n  new Box b\n  call b::init()\n  k += 1\n  r += b.xs[5]\n"),
+    # 内部的なメッセージが漏れていた経路
+    ("field access on an integer", "Field access needs an object on the left of the dot",
+     "class Box\n int f\n method noop()\n  skip\n\nclass Program\n int x\n method main()\n  x += x.f\n"),
+    ("delete on a nil object", "delete needs an allocated object",
+     "class Box\n int f\n method noop()\n  skip\n\nclass Program\n Box b\n method main()\n  delete Box b\n"),
     ("division by zero", "division by zero", prog("  x += 1 / y\n")),
     ("modulo by zero", "modulo by zero", prog("  x += 1 % y\n")),
     ("conditional exit assertion (then)", "Assertion should be true",

--- a/python/tests/test_errors.py
+++ b/python/tests/test_errors.py
@@ -88,6 +88,10 @@ CASES = [
     ("uncopy of an object with itself", "two different variables",
      "class Box\n int f\n method noop()\n  skip\n\n"
      "class Program\n Box b\n method main()\n  new Box b\n  uncopy Box b b\n"),
+    ("delete with a different class", "the class must match",
+     "class A\n int f\n method noop()\n  skip\n\n"
+     "class B\n int g\n int h\n method noop()\n  skip\n\n"
+     "class Program\n A a\n method main()\n  new A a\n  delete B a\n"),
     ("division by zero", "division by zero", prog("  x += 1 / y\n")),
     ("modulo by zero", "modulo by zero", prog("  x += 1 % y\n")),
     ("conditional exit assertion (then)", "Assertion should be true",

--- a/python/tests/test_errors.py
+++ b/python/tests/test_errors.py
@@ -64,6 +64,17 @@ CASES = [
      "must not mention the loop variable",
      prog("  local int i = 0\n  for i in (i..3) do\n   x += 1\n  end\n"
           "  delocal int i = 0\n")),
+    # 配列の要素数と条件式（内部メッセージが漏れていた経路）
+    ("array size is negative", "Array size must be at least 1",
+     prog("  new int[-1] a\n")),
+    ("array size is zero", "Array size must be at least 1",
+     prog("  new int[0] a\n")),
+    ("delete with a non-positive size", "Array size must be at least 1",
+     prog("  new int[2] a\n  delete int[0] a\n")),
+    ("a condition that is not an integer", "Integer value expected in the condition",
+     prog("  new int[2] a\n  if a then\n   skip\n  fi a\n")),
+    ("a loop condition that is not an integer", "Integer value expected in the condition",
+     prog("  new int[2] a\n  from a loop\n   skip\n  until a\n")),
     ("division by zero", "division by zero", prog("  x += 1 / y\n")),
     ("modulo by zero", "modulo by zero", prog("  x += 1 % y\n")),
     ("conditional exit assertion (then)", "Assertion should be true",

--- a/test/degenerate/array_delete_zero.rplpp
+++ b/test/degenerate/array_delete_zero.rplpp
@@ -1,0 +1,7 @@
+class Program
+    int x
+    int y
+    int[] a
+    method main()
+        new int[2] a
+        delete int[0] a

--- a/test/degenerate/array_size_negative.rplpp
+++ b/test/degenerate/array_size_negative.rplpp
@@ -1,0 +1,6 @@
+class Program
+    int x
+    int y
+    int[] a
+    method main()
+        new int[-1] a

--- a/test/degenerate/array_size_zero.rplpp
+++ b/test/degenerate/array_size_zero.rplpp
@@ -1,0 +1,6 @@
+class Program
+    int x
+    int y
+    int[] a
+    method main()
+        new int[0] a

--- a/test/degenerate/call_on_nil.rplpp
+++ b/test/degenerate/call_on_nil.rplpp
@@ -1,0 +1,9 @@
+class Box
+    int f
+    method noop()
+        skip
+
+class Program
+    Box b
+    method main()
+        call b::noop()

--- a/test/degenerate/cond_array_if.rplpp
+++ b/test/degenerate/cond_array_if.rplpp
@@ -1,0 +1,9 @@
+class Program
+    int x
+    int y
+    int[] a
+    method main()
+        new int[2] a
+        if a then
+         skip
+        fi a

--- a/test/degenerate/cond_array_loop.rplpp
+++ b/test/degenerate/cond_array_loop.rplpp
@@ -1,0 +1,9 @@
+class Program
+    int x
+    int y
+    int[] a
+    method main()
+        new int[2] a
+        from a loop
+         skip
+        until a

--- a/test/degenerate/delete_array_var.rplpp
+++ b/test/degenerate/delete_array_var.rplpp
@@ -1,0 +1,10 @@
+class Box
+    int f
+    method noop()
+        skip
+
+class Program
+    int[] a
+    method main()
+        new int[2] a
+        delete Box a

--- a/test/degenerate/delete_nil.rplpp
+++ b/test/degenerate/delete_nil.rplpp
@@ -1,0 +1,9 @@
+class Box
+    int f
+    method noop()
+        skip
+
+class Program
+    Box b
+    method main()
+        delete Box b

--- a/test/degenerate/delete_wrong_class.rplpp
+++ b/test/degenerate/delete_wrong_class.rplpp
@@ -1,0 +1,16 @@
+class A
+    int f
+    method noop()
+        skip
+
+class B
+    int g
+    int h
+    method noop()
+        skip
+
+class Program
+    A a
+    method main()
+        new A a
+        delete B a

--- a/test/degenerate/delocal_self_ref.rplpp
+++ b/test/degenerate/delocal_self_ref.rplpp
@@ -1,0 +1,9 @@
+class Program
+    int x
+    int y
+    int[] a
+    method main()
+        local int t = 0
+        t += 3
+        x += t
+        delocal int t = t

--- a/test/degenerate/div_by_zero.rplpp
+++ b/test/degenerate/div_by_zero.rplpp
@@ -1,0 +1,6 @@
+class Program
+    int x
+    int y
+    int[] a
+    method main()
+        x += 1 / y

--- a/test/degenerate/dot_on_array.rplpp
+++ b/test/degenerate/dot_on_array.rplpp
@@ -1,0 +1,11 @@
+class Box
+    int f
+    method noop()
+        skip
+
+class Program
+    int[] a
+    int x
+    method main()
+        new int[2] a
+        x += a.f

--- a/test/degenerate/dot_on_int.rplpp
+++ b/test/degenerate/dot_on_int.rplpp
@@ -1,0 +1,9 @@
+class Box
+    int f
+    method noop()
+        skip
+
+class Program
+    int x
+    method main()
+        x += x.f

--- a/test/degenerate/dot_on_nil.rplpp
+++ b/test/degenerate/dot_on_nil.rplpp
@@ -1,0 +1,10 @@
+class Box
+    int f
+    method noop()
+        skip
+
+class Program
+    Box b
+    int x
+    method main()
+        x += b.f

--- a/test/degenerate/field_array_oob.rplpp
+++ b/test/degenerate/field_array_oob.rplpp
@@ -1,0 +1,12 @@
+class Box
+    int[] xs
+    method init()
+        new int[3] xs
+
+class Program
+    int r
+    Box b
+    method main()
+        new Box b
+        call b::init()
+        r += b.xs[5]

--- a/test/degenerate/for_range_self.rplpp
+++ b/test/degenerate/for_range_self.rplpp
@@ -1,0 +1,10 @@
+class Program
+    int x
+    int y
+    int[] a
+    method main()
+        local int i = 3
+        for i in (0..i) do
+         x += 1
+        end
+        delocal int i = 3

--- a/test/degenerate/mod_by_zero.rplpp
+++ b/test/degenerate/mod_by_zero.rplpp
@@ -1,0 +1,6 @@
+class Program
+    int x
+    int y
+    int[] a
+    method main()
+        x += 1 % y

--- a/test/degenerate/new_on_allocated.rplpp
+++ b/test/degenerate/new_on_allocated.rplpp
@@ -1,0 +1,10 @@
+class Box
+    int f
+    method noop()
+        skip
+
+class Program
+    int[] a
+    method main()
+        new int[2] a
+        new Box a

--- a/test/degenerate/ok_copy_uncopy.rplpp
+++ b/test/degenerate/ok_copy_uncopy.rplpp
@@ -1,0 +1,13 @@
+class Box
+    int f
+    method noop()
+        skip
+
+class Program
+    Box b
+    Box c
+    method main()
+        new Box b
+        copy Box b c
+        uncopy Box b c
+        delete Box b

--- a/test/degenerate/ok_inherit_delete.rplpp
+++ b/test/degenerate/ok_inherit_delete.rplpp
@@ -1,0 +1,15 @@
+class Base
+    int f
+    method noop()
+        skip
+
+class Derived inherits Base
+    int g
+    method noop2()
+        skip
+
+class Program
+    Base b
+    method main()
+        new Derived b
+        delete Derived b

--- a/test/degenerate/ok_self_swap_call.rplpp
+++ b/test/degenerate/ok_self_swap_call.rplpp
@@ -1,0 +1,8 @@
+class Program
+    int x
+    method sw(int p, int q)
+        p <=> q
+    method main()
+        x += 5
+        call sw(x, x)
+        x -= 5

--- a/test/degenerate/self_assign.rplpp
+++ b/test/degenerate/self_assign.rplpp
@@ -1,0 +1,7 @@
+class Program
+    int x
+    int y
+    int[] a
+    method main()
+        x += 3
+        x += x

--- a/test/degenerate/self_assign_cell.rplpp
+++ b/test/degenerate/self_assign_cell.rplpp
@@ -1,0 +1,8 @@
+class Program
+    int x
+    int y
+    int[] a
+    method main()
+        new int[2] a
+        a[0] += 5
+        a[0] += a[0]

--- a/test/degenerate/swap_moves_index.rplpp
+++ b/test/degenerate/swap_moves_index.rplpp
@@ -1,0 +1,8 @@
+class Program
+    int x
+    int y
+    int[] a
+    method main()
+        new int[2] a
+        a[0] += 1
+        a[a[0]] <=> a[0]

--- a/test/degenerate/uncopy_self_int.rplpp
+++ b/test/degenerate/uncopy_self_int.rplpp
@@ -1,0 +1,7 @@
+class Program
+    int x
+    int y
+    int[] a
+    method main()
+        x += 1
+        uncopy int x x

--- a/test/degenerate/uncopy_self_obj.rplpp
+++ b/test/degenerate/uncopy_self_obj.rplpp
@@ -1,0 +1,10 @@
+class Box
+    int f
+    method noop()
+        skip
+
+class Program
+    Box b
+    method main()
+        new Box b
+        uncopy Box b b

--- a/test/degenerate/unknown_class.rplpp
+++ b/test/degenerate/unknown_class.rplpp
@@ -1,0 +1,4 @@
+class Program
+    Box b
+    method main()
+        new Box b

--- a/test/degenerate_test.ml
+++ b/test/degenerate_test.ml
@@ -1,0 +1,125 @@
+open OUnit2
+
+(* 退化した入力の掃引。
+
+   2026-08-05 の監査で見つけた 8 件のバグは、どれも「変な入力を実際に流して
+   出力を見る」ことで見つかった。手法そのものをテストにして固定する。
+
+   `test/degenerate/*.rplpp` を全部走らせて、次の 2 つを要求する。
+
+   1. **落ちるとしても行儀よく落ちること。** 素の例外（Stack_overflow、
+      Not_found など）で死んではいけない。`new int[-1]` が
+      `Fatal error: exception Stack_overflow` で終了コード 2 を返していたのは
+      これで捕まる。
+
+   2. **実装の内部事情がメッセージに漏れないこと。** 利用者に
+      `index out of bounds in lookup_vec` や `ERROR in isTrue` を見せない。
+      内部の語彙（下の [internal_vocabulary]）が出たら失敗させる。
+
+   3. **最後まで走るなら可逆であること。** `本体 ; その逆` で初期状態へ戻る。
+      可逆性のバグ（`call m(x,x)` の別名、`uncopy x x`、`x += x`）はどれも
+      「落ちずに黙って受理される」形なので、1 と 2 では捕まらない。ここが
+      効く。
+
+   新しい構文や検査を足したときは、退化させた入力をここへ追加する。 *)
+
+let dir =
+  let candidates = [ "../degenerate"; "test/degenerate"; "../../test/degenerate" ] in
+  try List.find (fun d -> Sys.file_exists (Filename.concat d "div_by_zero.rplpp"))
+        candidates
+  with Not_found -> assert_failure "test/degenerate/ が見つからない"
+
+let programs =
+  Sys.readdir dir |> Array.to_list
+  |> List.filter (fun f -> Filename.check_suffix f ".rplpp")
+  |> List.sort compare
+
+let read_file path =
+  let ch = open_in_bin path in
+  let s = really_input_string ch (in_channel_length ch) in
+  close_in ch; s
+
+(* 実装の内部でしか意味がない語。利用者向けメッセージに出てはいけない *)
+let internal_vocabulary =
+  [ "lookup_vec"; "isTrue"; "gen_st"; "gen_locsvec"; "lval_val";
+    "LocsVal"; "LocsVec"; "IntVal"; "ObjVal"; "l-value";
+    "not implemented"; "empty environment"; "unbound locations" ]
+
+let parse src = Parser.main Lexer.token (Lexing.from_string src)
+
+let run_source src = ignore (Eval.eval_prog (parse src))
+
+(* main の本体を「本体 ; その逆」に差し替える（example_test と同じ手口） *)
+let round_trip_prog (Syntax.Prog cl) =
+  Syntax.Prog
+    (List.map
+       (fun (Syntax.CDecl (tid, inh, fields, methods)) ->
+         Syntax.CDecl (tid, inh, fields,
+                List.map
+                  (fun (Syntax.MDecl (mid, para, stml)) ->
+                    if mid = "main"
+                    then Syntax.MDecl (mid, para, stml @ Invert.invert stml)
+                    else Syntax.MDecl (mid, para, stml))
+                  methods))
+       cl)
+
+let check name =
+  let src = read_file (Filename.concat dir name) in
+  let outcome =
+    try run_source src; `Ok with
+    | Util.Runtime_error m | Failure m -> `Rejected m
+    | Util.Parse_error _ -> `Rejected "(parse error)"
+    (* ここに来るのは素の例外で死んだということ。Stack_overflow や Not_found
+       が利用者に見えてはいけない *)
+    | e -> `Crashed (Printexc.to_string e)
+  in
+  match outcome with
+  | `Crashed e ->
+     assert_failure
+       (Printf.sprintf "%s: 行儀よく落ちていない（素の例外が出た）: %s" name e)
+  | `Ok ->
+     (* 走るなら可逆でなければならない *)
+     (match (try Some (Eval.eval_prog (round_trip_prog (parse src))) with
+             | Util.Runtime_error _ | Failure _ -> None) with
+      | None ->
+         assert_failure
+           (Printf.sprintf
+              "%s: 順方向は通るのに「本体 ; その逆」が落ちる（可逆でない）" name)
+      | Some result ->
+         (match List.filter (fun (_, v) -> not (Diagnostics.is_zero v)) result with
+          | [] -> ()
+          | dirty ->
+             assert_failure
+               (Printf.sprintf
+                  "%s: 順方向は通るのに往復で初期状態へ戻らない（%s が残った）"
+                  name (String.concat ", " (List.map fst dirty)))))
+  | `Rejected m ->
+     List.iter
+       (fun w ->
+         if Diagnostics.contains ~needle:w m then
+           assert_failure
+             (Printf.sprintf
+                "%s: 内部の語 %S が利用者向けメッセージに出ている:\n%s" name w m))
+       internal_vocabulary
+
+(* 対照: ok_ で始まるものは最後まで走らなければならない *)
+let check_ok name =
+  let src = read_file (Filename.concat dir name) in
+  try run_source src with
+  | Util.Runtime_error m | Failure m ->
+     assert_failure (Printf.sprintf "%s: 通るはずが落ちた:\n%s" name m)
+
+let suite = "test suite for degenerate inputs" >::: [
+      "the corpus is not empty" >:: (fun _ ->
+        assert_bool "退化入力が置かれている" (List.length programs >= 20));
+
+      "no degenerate input crashes or leaks internals"
+      >::: List.map (fun n -> n >:: (fun _ -> check n)) programs;
+
+      "the controls still run to completion"
+      >::: List.map (fun n -> n >:: (fun _ -> check_ok n))
+             (List.filter (fun n -> String.length n > 3 && String.sub n 0 3 = "ok_")
+                programs);
+    ]
+
+let _ = run_test_tt_main suite

--- a/test/degenerate_test.ml
+++ b/test/degenerate_test.ml
@@ -24,7 +24,10 @@ open OUnit2
    新しい構文や検査を足したときは、退化させた入力をここへ追加する。 *)
 
 let dir =
-  let candidates = [ "../degenerate"; "test/degenerate"; "../../test/degenerate" ] in
+  (* dune test は _build/default/test を、dune exec はリポジトリ直下を CWD に
+     するので、両方から見つかる候補を並べる *)
+  let candidates =
+    [ "degenerate"; "test/degenerate"; "../test/degenerate"; "../../test/degenerate" ] in
   try List.find (fun d -> Sys.file_exists (Filename.concat d "div_by_zero.rplpp"))
         candidates
   with Not_found -> assert_failure "test/degenerate/ が見つからない"

--- a/test/dune
+++ b/test/dune
@@ -1,7 +1,9 @@
 ; OUnit2 suites; each *_test.ml is its own test executable run by `dune test`.
 (tests
  (names eval_test invert_test print_test pretty_test env_store_test eval_prog_test
-        diagnostics_test error_test example_test cli_test extracted_test)
- ; example_test は example/*.rplpp を、cli_test は rplpp バイナリを使う
- (deps (glob_files ../example/*.rplpp) ../bin/main.exe)
+        diagnostics_test error_test example_test cli_test extracted_test
+        degenerate_test)
+ ; example_test は example/*.rplpp を、degenerate_test は degenerate/*.rplpp を、
+ ; cli_test は rplpp バイナリを使う
+ (deps (glob_files ../example/*.rplpp) (glob_files degenerate/*.rplpp) ../bin/main.exe)
  (libraries rooplpp roopl_extracted ounit2))

--- a/test/error_test.ml
+++ b/test/error_test.ml
@@ -120,6 +120,19 @@ let suite = "test suite for runtime error paths" >::: [
   case "an out-of-bounds index through a field" "Array index xs[5] is out of bounds"
     ("class Box\n int[] xs\n int k\n method init()\n  new int[3] xs\n  k += 2\n  xs[0] += 100\n  xs[1] += 200\n  xs[2] += 300\n\nclass Program\n int r\n int k\n Box b\n method main()\n  new Box b\n  call b::init()\n  k += 1\n  r += b.xs[5]\n");
 
+  (* ---- 内部的なメッセージが漏れていた経路（利用者向けに書き直した） ---- *)
+  case "field access on an integer" "Field access needs an object on the left of the dot"
+    ("class Box\n int f\n method noop()\n  skip\n\nclass Program\n int x\n method main()\n  x += x.f\n");
+
+  case "field access on a nil object" "Field access needs an object on the left of the dot"
+    ("class Box\n int f\n method noop()\n  skip\n\nclass Program\n Box b\n int x\n method main()\n  x += b.f\n");
+
+  case "delete on a nil object" "delete needs an allocated object"
+    ("class Box\n int f\n method noop()\n  skip\n\nclass Program\n Box b\n method main()\n  delete Box b\n");
+
+  case "delete on an array variable" "delete needs an allocated object"
+    ("class Box\n int f\n method noop()\n  skip\n\nclass Program\n int[] a\n method main()\n  new int[2] a\n  delete Box a\n");
+
   (* ---- 算術 -------------------------------------------------------- *)
   case "division by zero" "division by zero"
     (prog "  x += 1 / y\n");
@@ -184,7 +197,7 @@ let suite = "test suite for runtime error paths" >::: [
     ("class T\n method two(int m, int n)\n  m += n\n\n"
      ^ prog "  local T t = nil\n  new T t\n  call t::two(x)\n  delete T t\n  delocal T t = nil\n");
 
-  case "method call on a nil object" "expected location value for object call"
+  case "method call on a nil object" "The receiver of this call is nil or not an object"
     ("class T\n method noop()\n  skip\n\n"
      ^ prog "  local T t = nil\n  call t::noop()\n  delocal T t = nil\n");
 
@@ -195,7 +208,7 @@ let suite = "test suite for runtime error paths" >::: [
   case "no main method" "was not found"
     "class C\n int v\n method notMain()\n  v += 1\n";
 
-  case "unknown class in new" "is not valid"
+  case "unknown class in new" "is not declared in this program"
     (prog "  local Missing m = nil\n  new Missing m\n  delocal Missing m = nil\n");
 
   (* ---- for --------------------------------------------------------- *)

--- a/test/error_test.ml
+++ b/test/error_test.ml
@@ -113,6 +113,13 @@ let suite = "test suite for runtime error paths" >::: [
   case "a loop condition that is not an integer" "Integer value expected in the condition"
     (prog "  new int[2] a\n  from a loop\n   skip\n  until a\n");
 
+  (* ---- ドットの右側の添字はどのスコープか ----------------------------
+     o.xs[k] の添字 k は**呼び出し側**の k であって、オブジェクトのフィールド k
+     ではない。以前は l 値の解決がフィールド側の環境で右辺全体を評価していて、
+     内側の k を拾っていた *)
+  case "an out-of-bounds index through a field" "Array index xs[5] is out of bounds"
+    ("class Box\n int[] xs\n int k\n method init()\n  new int[3] xs\n  k += 2\n  xs[0] += 100\n  xs[1] += 200\n  xs[2] += 300\n\nclass Program\n int r\n int k\n Box b\n method main()\n  new Box b\n  call b::init()\n  k += 1\n  r += b.xs[5]\n");
+
   (* ---- 算術 -------------------------------------------------------- *)
   case "division by zero" "division by zero"
     (prog "  x += 1 / y\n");

--- a/test/error_test.ml
+++ b/test/error_test.ml
@@ -92,6 +92,27 @@ let suite = "test suite for runtime error paths" >::: [
     (prog "  local int i = 0\n  for i in (i..3) do\n   x += 1\n  end\n"
      ^ "  delocal int i = 0\n");
 
+  (* ---- 配列の要素数と条件式（内部メッセージが漏れていた経路） ----------
+     new int[-1] は gen_locsvec が n <> 0 で再帰していたため Stack_overflow で
+     クラッシュしていた（終了コード 2）。new int[0] は lookup_vec の内部
+     メッセージが出ていた *)
+  case "array size is negative" "Array size must be at least 1"
+    (prog "  new int[-1] a\n");
+
+  case "array size is zero" "Array size must be at least 1"
+    (prog "  new int[0] a\n");
+
+  case "delete with a non-positive size" "Array size must be at least 1"
+    (prog "  new int[2] a\n  delete int[0] a\n");
+
+  (* 条件式に整数でない値（配列やオブジェクト）を置くと isTrue の内部
+     メッセージが出ていた *)
+  case "a condition that is not an integer" "Integer value expected in the condition"
+    (prog "  new int[2] a\n  if a then\n   skip\n  fi a\n");
+
+  case "a loop condition that is not an integer" "Integer value expected in the condition"
+    (prog "  new int[2] a\n  from a loop\n   skip\n  until a\n");
+
   (* ---- 算術 -------------------------------------------------------- *)
   case "division by zero" "division by zero"
     (prog "  x += 1 / y\n");

--- a/test/error_test.ml
+++ b/test/error_test.ml
@@ -148,6 +148,19 @@ let suite = "test suite for runtime error paths" >::: [
     ("class Box\n int f\n method noop()\n  skip\n\n"
      ^ "class Program\n Box b\n method main()\n  new Box b\n  uncopy Box b b\n");
 
+  (* ---- delete のクラスが実際のクラスと一致すること（E_delete の hc a l = cl）
+     一致を見ていなかったので、フィールド数の違うクラス名で delete すると
+     消すロケーション数がずれてストアが壊れ、あとで unbound locations になった *)
+  case "delete with a different class" "the class must match"
+    ("class A\n int f\n method noop()\n  skip\n\n"
+     ^ "class B\n int g\n int h\n method noop()\n  skip\n\n"
+     ^ "class Program\n A a\n method main()\n  new A a\n  delete B a\n");
+
+  case "delete a subclass instance as its superclass" "the class must match"
+    ("class Base\n int f\n method noop()\n  skip\n\n"
+     ^ "class Derived inherits Base\n int g\n method noop2()\n  skip\n\n"
+     ^ "class Program\n Base b\n method main()\n  new Derived b\n  delete Base b\n");
+
   (* ---- 算術 -------------------------------------------------------- *)
   case "division by zero" "division by zero"
     (prog "  x += 1 / y\n");

--- a/test/error_test.ml
+++ b/test/error_test.ml
@@ -133,6 +133,21 @@ let suite = "test suite for runtime error paths" >::: [
   case "delete on an array variable" "delete needs an allocated object"
     ("class Box\n int f\n method noop()\n  skip\n\nclass Program\n int[] a\n method main()\n  new int[2] a\n  delete Box a\n");
 
+  (* ---- copy / uncopy の自己別名（E_copy / E_uncopy の x ≠ y） ----------
+     uncopy int x x は x の値を消してしまい、逆向きに走らせても戻らない。
+     オブジェクトだと参照が消えて、確保済みのオブジェクトが回収不能になる
+     （しかもゼロクリア検査は「garbage なし」と報告してしまう） *)
+  case "uncopy of an integer variable with itself" "two different variables"
+    (prog "  x += 1\n  uncopy int x x\n");
+
+  case "copy of a variable with itself" "two different variables"
+    ("class Box\n int f\n method noop()\n  skip\n\n"
+     ^ "class Program\n Box b\n method main()\n  new Box b\n  copy Box b b\n");
+
+  case "uncopy of an object with itself" "two different variables"
+    ("class Box\n int f\n method noop()\n  skip\n\n"
+     ^ "class Program\n Box b\n method main()\n  new Box b\n  uncopy Box b b\n");
+
   (* ---- 算術 -------------------------------------------------------- *)
   case "division by zero" "division by zero"
     (prog "  x += 1 / y\n");

--- a/test/example_test.ml
+++ b/test/example_test.ml
@@ -120,6 +120,8 @@ let assert_values name expected =
    ファイル冒頭のコメントが主張している答え（手計算で確認済み）。 *)
 let rewritten_expectations = [
   (* 履歴を引く形へ直したもの *)
+  (* ドットの右側の添字は呼び出し側のスコープ（Box の k=2 ではなく Program の k=1）*)
+  "objectArrayIndexScope.rplpp", [ ("r", 200) ];
   "algo_newton_sqrt.rplpp", [ ("root", 12); ("steps", 5) ];          (* isqrt 144 *)
   "algo_collatz.rplpp",
   [ ("traj[0]", 6); ("traj[1]", 3); ("traj[2]", 10); ("traj[8]", 1); ("steps", 8) ];

--- a/test/extracted_test.ml
+++ b/test/extracted_test.ml
@@ -725,6 +725,10 @@ let p_copy_not_nil =
 (* 同じ変数への複製（別名禁止の規則そのもの） *)
 let p_copy_self = R.Sobj (nat_of_int 0, v 5, R.Scopy (v 5, v 5))
 
+(* 同じ変数の uncopy。形式側は E_uncopy の x ≠ y で弾く。実装はこれを通して
+   しまい、値を消して往復しなくなっていた（2026-08-05 修正） *)
+let p_uncopy_self = R.Sobj (nat_of_int 0, v 5, R.Suncopy (v 5, v 5))
+
 (* uncopy の両者が別の参照（両方で落ちるはず） *)
 let p_uncopy_mismatch =
   R.Sobj (nat_of_int 0, v 5,
@@ -927,12 +931,14 @@ let suite = "test suite for the extracted verified interpreter" >::: [
       agree "copy and uncopy of a reference" p_copy_uncopy [ 0 ];
       agree "copy onto a variable that is not nil is rejected" p_copy_not_nil [ 0 ];
       agree "copy onto itself is rejected" p_copy_self [ 0 ];
+      agree "uncopy of a variable with itself is rejected" p_uncopy_self [ 0 ];
       agree "uncopy of two different references is rejected" p_uncopy_mismatch [ 0 ];
 
       "the verified interpreter runs copy and uncopy" >:: (fun _ ->
         assert_equal ~printer (Some [ 3 ]) (run_verified p_copy_uncopy [ 0 ]);
         assert_equal ~printer None (run_verified p_copy_not_nil [ 0 ]);
         assert_equal ~printer None (run_verified p_copy_self [ 0 ]);
+        assert_equal ~printer None (run_verified p_uncopy_self [ 0 ]);
         assert_equal ~printer None (run_verified p_uncopy_mismatch [ 0 ]));
 
       (* ゼロクリアを忘れたオブジェクトブロックは意味論どおり落ちる *)


### PR DESCRIPTION
可逆性監査の続き。**実装のバグ 4 件**（うち 2 件は計算結果が壊れる）と、それを
見つけた**手法そのもののテスト化**。

## 直したバグ

### 1. 負の要素数でクラッシュ

`new int[-1] a` が `Fatal error: exception Stack_overflow`（終了コード 2）。
`gen_locsvec` が `n <> 0` で再帰するので、要素数が負だと 0 を通り越して無限に
降りていく。要素数は 1 以上を要求する（PyJanus も `int x[0]` を弾く）。

### 2. ドットの右側の添字が誤ったスコープ ← 計算結果が壊れる

    class Box     int[] xs  int k     // Box の k = 2, xs = [100,200,300]
    class Program int r     int k     // Program の k = 1
        r += b.xs[k]        // 300 を返していた（正しくは 200）
        b.xs[k] += 55       // xs[2] を書いていた（正しくは xs[1]）

l 値の解決がドットの右側をまるごとフィールド側の環境で評価していた。名前の解決に
使う環境と**添字を評価する環境を別に持ち回る**ように直した（式と文の両方、
OCaml と Python の 4 箇所）。この経路はテストが一度も通っていなかった。

### 3. `uncopy` の自己別名が値を消す ← 可逆性が壊れる

    x += 1 ; uncopy int x x ; copy int x x ; x -= 1     // -1（往復しない）

オブジェクトだと参照が消えて**確保済みのオブジェクトが回収不能**になり、しかも
ゼロクリア検査が「garbage なし」と誤報告する。形式側の `E_copy` / `E_uncopy` は
`x ≠ y` を要求している。**値ではなくロケーションで比べる**（別の変数が同じ
オブジェクトを指すのは uncopy の正当な使い方なので、値で比べると正当な場合まで
弾く）。

### 4. `delete` がクラス名を検査しない ← ストアが壊れる

`class A { int f }` と `class B { int g; int h }` があるとき、`new A a` して
`delete B a` が通り、消すロケーション数がずれて後続が
`ERROR:unbound locations: 7` になる。形式側の `E_delete` は `hc a l = cl` を
要求している。`ObjVal` の実行時クラスと突き合わせて弾く（継承していても完全一致
を要求。形式側も部分型は許さない）。

## 見つけ方（と、その常設化）

`coq/roopl.v` の `exec` 22 規則の**前提を機械抽出して実装の検査と照合**した。
結果は 18 が検査あり・1 が今回修正（4）・1 が害なしと判断（`E_delete` の
「ヒープの一番上を解放」。実装のストアは写像なので順序を守らなくても往復は
壊れない）・2 が構造的に自動成立。

それとは別に、**退化した入力を実際に流す掃引**でバグが出続けたので、手法自体を
テストにした（`test/degenerate_test.ml` + `test/degenerate/*.rplpp` 29 本）。
3 つを要求する。

1. 落ちるとしても**行儀よく落ちる**（素の例外で死なない）
2. **内部事情が漏れない**（`lookup_vec` `isTrue` `LocsVal` などの語彙）
3. 最後まで走るなら**可逆**（`本体 ; その逆` で初期状態へ戻る）

3 が要点。可逆性のバグは「落ちずに黙って受理される」形なので 1・2 では捕まらない。
`ok_` で始まる 3 本は対照で、検査を厳しくしすぎていないかを見る。

**効くことを実証済み**: 修正前のリビジョン (bfe8109) にこのテストだけを移すと
5 件が赤くなる。

## ついでに直したもの

利用者に出ていた内部メッセージ 9 通り（`expected location value for dot access`
→ `Field access needs an object on the left of the dot, …` など）。**両実装の
ずれも 1 件**見つかった（Python は `delete` にも「呼び出しの受け手が…」と出て
いた）。未使用だった `myassert` を削除、`.gitignore` に `*.coverage` を追加。

## エンバグではないことの確認

セッション開始時点 (bfe8109) を `git worktree` でビルドして 9 本のプログラムを
流し、**すべて同じ挙動**であることを確認した。最初のコミット (82ed810) の
`src/eval.ml` には副条件の検査が 1 つも無い。当初から未実装だったもので、
形式化を作って初めて可視化された。

性能の退行も見た: 例題 159 本の総実行時間は 0.80s → 0.74s、159/159 正常終了。

## 検証済みのこと

- [x] `dune test --force` 19 スイート全通過（手元）— error 63 件・掃引 33 件・
      例題 360 件・差分 71 件
- [x] `python3 -m pytest -q` 245 件全通過（手元）
- [x] `dune build` 警告ゼロ（手元）
- [x] 修正前リビジョンで掃引テストが 5 件赤くなる（手元）
- [x] gitleaks クリーン
